### PR TITLE
User in activity table

### DIFF
--- a/src/App/activity.resolver.ts
+++ b/src/App/activity.resolver.ts
@@ -10,6 +10,12 @@ class ActivityArgs extends PaginationArgs {
 }
 
 @ArgsType()
+class ActivityArgsByUser extends PaginationArgs {
+  @Field(() => String)
+  userId!: string
+}
+
+@ArgsType()
 class LangArgs extends PaginationArgs {
   @Field(() => String)
   lang = 'en'
@@ -42,6 +48,19 @@ class ActivityResolver {
       skip: args.offset,
       order: {
         datetime: 'DESC',
+      },
+    })
+  }
+
+  @Query(() => [Activity])
+  async activitiesByUser(@Args() args: ActivityArgsByUser) {
+    const repository = this.connection.getRepository(Activity)
+
+    return repository.find({
+      where: {
+        user: {
+          id: args.userId,
+        },
       },
     })
   }

--- a/src/App/activity.resolver.ts
+++ b/src/App/activity.resolver.ts
@@ -62,6 +62,8 @@ class ActivityResolver {
           id: args.userId,
         },
       },
+      take: args.limit,
+      skip: args.offset,
       order: {
         datetime: 'DESC',
       },

--- a/src/App/activity.resolver.ts
+++ b/src/App/activity.resolver.ts
@@ -62,6 +62,9 @@ class ActivityResolver {
           id: args.userId,
         },
       },
+      order: {
+        datetime: 'DESC',
+      },
     })
   }
 }

--- a/src/App/tokenStats/tokenStats.module.ts
+++ b/src/App/tokenStats/tokenStats.module.ts
@@ -5,10 +5,7 @@ import TokenStatsService from './tokenStats.service'
 import StatsGetterService from './CryptoStats/stats-getter.service'
 
 @Module({
-  imports: [
-    httpModule(20000),
-    CacheModule.register({ ttl: 30 }),
-  ],
+  imports: [httpModule(20000), CacheModule.register({ ttl: 30 })],
   providers: [TokenStatsResolver, TokenStatsService, StatsGetterService],
 })
 export default class TokenStatsModule {}

--- a/src/App/tokenStats/tokenStats.resolver.ts
+++ b/src/App/tokenStats/tokenStats.resolver.ts
@@ -10,7 +10,9 @@ class TokenStatsResolver {
   async getTokenStats(
     @Args({ name: 'tokenName', type: () => String }) tokenName: string,
   ): Promise<TokenData> {
-    const result = await this.tokenStatsService.getStats(tokenName.toLowerCase())
+    const result = await this.tokenStatsService.getStats(
+      tokenName.toLowerCase(),
+    )
     return result
   }
 }

--- a/src/Database/Entities/activity.entity.ts
+++ b/src/Database/Entities/activity.entity.ts
@@ -2,8 +2,10 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  ManyToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm'
+
 import {
   Field,
   GraphQLISODateTime,
@@ -11,7 +13,9 @@ import {
   ObjectType,
   registerEnumType,
 } from '@nestjs/graphql'
+
 import Wiki from './wiki.entity'
+import User from './user.entity'
 
 export enum Status {
   CREATED,
@@ -28,6 +32,10 @@ class Activity {
   @Field(() => ID)
   @PrimaryGeneratedColumn('uuid')
   id!: string
+
+  @Field(() => User)
+  @ManyToOne('User', 'user', { lazy: true })
+  user!: User
 
   @Field()
   @Column('varchar')

--- a/src/Indexer/Store/store.service.ts
+++ b/src/Indexer/Store/store.service.ts
@@ -92,6 +92,7 @@ class DBStoreService {
       const resp = activityRepository.create({
         wikiId: wiki.id,
         type: typ,
+        user,
         content: [
           {
             id: wiki.id,

--- a/src/Relayer/relayer.module.ts
+++ b/src/Relayer/relayer.module.ts
@@ -6,9 +6,7 @@ import RelayerResolver from './resolvers/relayer.resolver'
 import httpModule from '../httpModule'
 
 @Module({
-  imports: [
-    httpModule(10000),
-  ],
+  imports: [httpModule(10000)],
   controllers: [RelayerController],
   providers: [RelayerService, RelayerResolver],
 })


### PR DESCRIPTION
# User field Added to Activity table

_Now we have an user field that needs to be filled/registered every time a new activity goes in and so you can get it on a basic Activity query. Also now we have a query to filter Activity by User ID too._

## How should this be tested?

1. Run the API
2. Create a new Wiki 
3. Run graphQL Playground and run the queries for User in Activities or Activities where User ID equals your User ID.

## Notes or observations

_I added the new query thinking it might be cool if we'd have a future feature where user wants to check out his activity history or something like that. There goes our new query running along with our new field added to the schema:_
![image](https://user-images.githubusercontent.com/28926336/165484513-8089f320-0f2a-4584-9571-3d3d6a99a380.png)


## Linked issues

closes #00, closes #001, closes https://github.com/EveripediaNetwork/issues/issues/270
