### PR TITLE
Externa links validation

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -16,4 +16,4 @@ COINMARKETCAP_API_KEY=
 IPFS_PINATA_KEY=
 IPFS_PINATA_SECRET=
 
-UI_URL='https://alpha.everipedia.org'
+UI_URL='https://alpha.everipedia.org/'

--- a/.sample.env
+++ b/.sample.env
@@ -15,3 +15,5 @@ COINMARKETCAP_API_KEY=
 
 IPFS_PINATA_KEY=
 IPFS_PINATA_SECRET=
+
+UI_URL='https://alpha.everipedia.org'

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "graphql-request": "^4.0.0",
     "graphql-upload": "^13.0.0",
     "jest-mock": "^27.5.1",
+    "linkifyjs": "^3.0.5",
     "mysql2": "^2.3.3",
     "nest-commander": "^2.4.0",
     "pg": "^8.7.3",

--- a/src/App/pinJSONAndImage/pin.service.ts
+++ b/src/App/pinJSONAndImage/pin.service.ts
@@ -14,7 +14,7 @@ class PinService {
   constructor(
     private configService: ConfigService,
     private activityService: ActivityService,
-    private validatorService: IPFSValidatorService
+    private validatorService: IPFSValidatorService,
   ) {}
 
   private pinata() {

--- a/src/App/pinJSONAndImage/pin.service.ts
+++ b/src/App/pinJSONAndImage/pin.service.ts
@@ -14,9 +14,8 @@ class PinService {
   constructor(
     private configService: ConfigService,
     private activityService: ActivityService,
+    private validatorService: IPFSValidatorService
   ) {}
-
-  private validator: IPFSValidatorService = new IPFSValidatorService()
 
   private pinata() {
     const key = this.configService.get<string>('IPFS_PINATA_KEY')
@@ -41,7 +40,7 @@ class PinService {
 
   async pinJSON(body: string): Promise<IpfsHash | any> {
     const data = JSON.parse(`${body}`)
-    const isDataValid = await this.validator.validate(data, true)
+    const isDataValid = await this.validatorService.validate(data, true)
 
     if (!isDataValid) {
       throw new HttpException(

--- a/src/App/pinJSONAndImage/pin.service.ts
+++ b/src/App/pinJSONAndImage/pin.service.ts
@@ -14,8 +14,9 @@ class PinService {
   constructor(
     private configService: ConfigService,
     private activityService: ActivityService,
-    private validatorService: IPFSValidatorService,
   ) {}
+
+  private validator: IPFSValidatorService = new IPFSValidatorService()
 
   private pinata() {
     const key = this.configService.get<string>('IPFS_PINATA_KEY')
@@ -40,7 +41,7 @@ class PinService {
 
   async pinJSON(body: string): Promise<IpfsHash | any> {
     const data = JSON.parse(`${body}`)
-    const isDataValid = await this.validatorService.validate(data, true)
+    const isDataValid = await this.validator.validate(data, true)
 
     if (!isDataValid) {
       throw new HttpException(

--- a/src/Indexer/Validator/validator.service.ts
+++ b/src/Indexer/Validator/validator.service.ts
@@ -1,8 +1,16 @@
 import { Injectable } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
+
+import * as linkify from 'linkifyjs';
+
 import { ValidWiki } from '../Store/store.service'
 
 @Injectable()
 class IPFSValidatorService {
+  constructor(
+    private configService: ConfigService,
+  ){}
+
   async validate(
     wiki: ValidWiki,
     validateJSON?: boolean,
@@ -44,6 +52,19 @@ class IPFSValidatorService {
       return false
     }
 
+    const checkExternalUrls = (validatingWiki: ValidWiki) => {
+      const links = linkify.find(validatingWiki.content)
+      const uiLink = this.configService.get('UI_URL')
+
+      let externalURLs = links.filter(link => {
+        return link.isLink && !link.href.includes(uiLink)
+      })
+
+      if(externalURLs.length === 0) return true
+
+      return false
+    }
+
     const checkTags = (validatingWiki: ValidWiki) =>
       validatingWiki.images.length <= 5
 
@@ -56,7 +77,8 @@ class IPFSValidatorService {
       checkUser(wiki) &&
       checkTags(wiki) &&
       checkSummary(wiki) &&
-      checkImages(wiki)
+      checkImages(wiki) &&
+      checkExternalUrls(wiki)
     )
   }
 }

--- a/src/Indexer/Validator/validator.service.ts
+++ b/src/Indexer/Validator/validator.service.ts
@@ -7,7 +7,7 @@ import { ValidWiki } from '../Store/store.service'
 
 @Injectable()
 class IPFSValidatorService {
-  constructor(private configService: ConfigService) {}
+  private configService: ConfigService = new ConfigService()
 
   async validate(
     wiki: ValidWiki,

--- a/src/Indexer/Validator/validator.service.ts
+++ b/src/Indexer/Validator/validator.service.ts
@@ -55,7 +55,7 @@ class IPFSValidatorService {
       const uiLink = this.configService.get('UI_URL')
 
       const externalURLs = links.filter(
-        link => link.isLink && !link.href.includes(uiLink),
+        link => link.isLink && !link.href.startsWith(uiLink),
       )
 
       if (externalURLs.length === 0) return true

--- a/src/Indexer/Validator/validator.service.ts
+++ b/src/Indexer/Validator/validator.service.ts
@@ -1,15 +1,13 @@
 import { Injectable } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 
-import * as linkify from 'linkifyjs';
+import * as linkify from 'linkifyjs'
 
 import { ValidWiki } from '../Store/store.service'
 
 @Injectable()
 class IPFSValidatorService {
-  constructor(
-    private configService: ConfigService,
-  ){}
+  constructor(private configService: ConfigService) {}
 
   async validate(
     wiki: ValidWiki,
@@ -56,11 +54,9 @@ class IPFSValidatorService {
       const links = linkify.find(validatingWiki.content)
       const uiLink = this.configService.get('UI_URL')
 
-      let externalURLs = links.filter(link => {
-        return link.isLink && !link.href.includes(uiLink)
-      })
+      const externalURLs = links.filter(link => link.isLink && !link.href.includes(uiLink))
 
-      if(externalURLs.length === 0) return true
+      if (externalURLs.length === 0) return true
 
       return false
     }

--- a/src/Indexer/Validator/validator.service.ts
+++ b/src/Indexer/Validator/validator.service.ts
@@ -54,7 +54,9 @@ class IPFSValidatorService {
       const links = linkify.find(validatingWiki.content)
       const uiLink = this.configService.get('UI_URL')
 
-      const externalURLs = links.filter(link => link.isLink && !link.href.includes(uiLink))
+      const externalURLs = links.filter(
+        link => link.isLink && !link.href.includes(uiLink),
+      )
 
       if (externalURLs.length === 0) return true
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5218,6 +5218,11 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
+linkifyjs@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/linkifyjs/-/linkifyjs-3.0.5.tgz#99e51a3a0c0e232fcb63ebb89eea3ff923378f34"
+  integrity sha512-1Y9XQH65eQKA9p2xtk+zxvnTeQBG7rdAXSkUG97DmuI/Xhji9uaUzaWxRj6rf9YC0v8KKHkxav7tnLX82Sz5Fg==
+
 lint-staged@^12.1.3:
   version "12.3.4"
   resolved "https://registry.npmjs.org/lint-staged/-/lint-staged-12.3.4.tgz"


### PR DESCRIPTION
# Externa links validation

_Now we validate links that are in the wiki content so we won't allow external links other than our own links. It gets the links from the .env which reads the value 'everipedia.org/', so we don't really need to change it from the alpha/dev for the actual production - I will add it in the server! so it checks if the link in the wiki content is our own or not, if not, the wiki gets invalidated._

## How should this be tested?

1. Create a wiki with links
2. Run indexer service (if locally)
3. Check logs for the validation
4. Re-run the same with external links other than our own.

## Notes or observations

_I had a small problem with nestjs and .envs as usual 😅 that's the reason of the late time of delivery for this. but it's done before closing on one more day and kinda of still on the time! XD_

## Linked issues

closes #00, closes #001, closes https://github.com/EveripediaNetwork/issues/issues/301
