### PR TITLE
Timestamps/activity content

### DIFF
--- a/src/App/activity.resolver.ts
+++ b/src/App/activity.resolver.ts
@@ -58,7 +58,6 @@ class ActivityResolver {
   @Query(() => [Activity])
   async activitiesByUser(@Args() args: ActivityArgsByUser) {
     const repository = this.connection.getRepository(Activity)
-
     return repository.find({
       where: {
         user: {
@@ -74,9 +73,13 @@ class ActivityResolver {
   }
 
   @Query(() => Activity)
-  async activityById(@Args('id', { type: () => String }) id: string) {
+  async activityById(@Args('wikiId', { type: () => String }) wikiId: string) {
     const repository = this.connection.getRepository(Activity)
-    return repository.findOneOrFail(id)
+    return repository.findOneOrFail({
+      where: {
+        wikiId,
+      },
+    })
   }
 }
 

--- a/src/App/app.module.ts
+++ b/src/App/app.module.ts
@@ -27,7 +27,7 @@ import TokenStatsModule from './tokenStats/tokenStats.module'
       debug: true,
       playground: true,
       cors: true,
-      autoSchemaFile: true,
+      autoSchemaFile: true
     }),
     PinModule,
     DatabaseModule,

--- a/src/Database/Entities/wiki.entity.ts
+++ b/src/Database/Entities/wiki.entity.ts
@@ -12,7 +12,16 @@ import {
   AfterInsert,
   AfterUpdate,
 } from 'typeorm'
-import { Field, GraphQLISODateTime, ID, Int, ObjectType , FieldMiddleware, MiddlewareContext, NextFn } from '@nestjs/graphql'
+import {
+  Field,
+  GraphQLISODateTime,
+  ID,
+  Int,
+  ObjectType,
+  FieldMiddleware,
+  MiddlewareContext,
+  NextFn,
+} from '@nestjs/graphql'
 
 import Category from './category.entity'
 import Tag from './tag.entity'
@@ -23,13 +32,12 @@ import Media from './media.entity'
 import Image from './image.entity'
 import { Author } from './types/IUser'
 
-
 const dateMiddleware: FieldMiddleware = async (
   ctx: MiddlewareContext,
   next: NextFn,
 ) => {
   const value = await next()
-  if(value === undefined){
+  if (value === undefined) {
     return null
   }
   return new Date(value)
@@ -48,11 +56,17 @@ class Wiki {
   @Column()
   title!: string
 
-  @Field(() => GraphQLISODateTime, { middleware: [dateMiddleware], nullable: true })
+  @Field(() => GraphQLISODateTime, {
+    middleware: [dateMiddleware],
+    nullable: true,
+  })
   @CreateDateColumn()
   created!: Date
 
-  @Field(() => GraphQLISODateTime, { middleware: [dateMiddleware], nullable: true })
+  @Field(() => GraphQLISODateTime, {
+    middleware: [dateMiddleware],
+    nullable: true,
+  })
   @UpdateDateColumn()
   updated!: Date
 

--- a/src/Database/Entities/wiki.entity.ts
+++ b/src/Database/Entities/wiki.entity.ts
@@ -12,7 +12,7 @@ import {
   AfterInsert,
   AfterUpdate,
 } from 'typeorm'
-import { Field, GraphQLISODateTime, ID, Int, ObjectType } from '@nestjs/graphql'
+import { Field, GraphQLISODateTime, ID, Int, ObjectType , FieldMiddleware, MiddlewareContext, NextFn } from '@nestjs/graphql'
 
 import Category from './category.entity'
 import Tag from './tag.entity'
@@ -22,6 +22,18 @@ import Metadata from './metadata.entity'
 import Media from './media.entity'
 import Image from './image.entity'
 import { Author } from './types/IUser'
+
+
+const dateMiddleware: FieldMiddleware = async (
+  ctx: MiddlewareContext,
+  next: NextFn,
+) => {
+  const value = await next()
+  if(value === undefined){
+    return null
+  }
+  return new Date(value)
+}
 
 @ObjectType()
 @Entity()
@@ -36,11 +48,11 @@ class Wiki {
   @Column()
   title!: string
 
-  @Field(() => GraphQLISODateTime)
+  @Field(() => GraphQLISODateTime, { middleware: [dateMiddleware], nullable: true })
   @CreateDateColumn()
   created!: Date
 
-  @Field(() => GraphQLISODateTime)
+  @Field(() => GraphQLISODateTime, { middleware: [dateMiddleware], nullable: true })
   @UpdateDateColumn()
   updated!: Date
 

--- a/src/Indexer/Store/store.service.ts
+++ b/src/Indexer/Store/store.service.ts
@@ -114,7 +114,8 @@ class DBStoreService {
             language,
             user,
             tags,
-            created: `${existWiki?.created}` || new Date(Date.now()).toISOString(),
+            created:
+              `${existWiki?.created}` || new Date(Date.now()).toISOString(),
             updated: new Date(Date.now()).toISOString(),
             categories,
             images: wiki.images,

--- a/src/Indexer/Store/store.service.ts
+++ b/src/Indexer/Store/store.service.ts
@@ -17,6 +17,8 @@ export type ValidWiki = {
   title: string
   content: string
   summary?: string
+  created?: Date
+  updated?: Date
   tags: {
     id: string
   }[]
@@ -112,6 +114,8 @@ class DBStoreService {
             language,
             user,
             tags,
+            created: `${existWiki?.created}` || new Date(Date.now()).toISOString(),
+            updated: new Date(Date.now()).toISOString(),
             categories,
             images: wiki.images,
             media: wiki.media || [],
@@ -120,7 +124,7 @@ class DBStoreService {
             ipfs: hash.id,
           },
         ],
-        datetime: new Date(Date.now()),
+        datetime: new Date(Date.now()).toISOString(),
         ipfs: hash.id,
       })
       return resp


### PR DESCRIPTION
# Timestamps in activity content

_Wiki timestamps were undefined in Activity content(jsonb) of Wiki[]. Adding the timestamps in the json were returning string values which in turn is not a valid object for datetime serialization. Solution is to use a field middleware that recreates the json date strings as valid objects to be serialized by graphql when queried._

## How should this be tested?

<img width="2056" alt="image" src="https://user-images.githubusercontent.com/67957533/175279751-6a4142a4-24b9-48bf-916d-487641eae052.png">

## Notes or observations

_Older Wikis have null timestamps but new Wikis and Activities will receive this update_

## Linked issues

closes a part of https://github.com/EveripediaNetwork/issues/issues/401
