### PR TITLE
Resolve activity create date for new wikis

### DIFF
--- a/src/Indexer/Store/store.service.ts
+++ b/src/Indexer/Store/store.service.ts
@@ -114,9 +114,8 @@ class DBStoreService {
             language,
             user,
             tags,
-            created:
-              `${existWiki?.created}` || new Date(Date.now()).toISOString(),
-            updated: new Date(Date.now()).toISOString(),
+            created: existWiki?.created || new Date(Date.now()),
+            updated: new Date(Date.now()),
             categories,
             images: wiki.images,
             media: wiki.media || [],
@@ -125,7 +124,7 @@ class DBStoreService {
             ipfs: hash.id,
           },
         ],
-        datetime: new Date(Date.now()).toISOString(),
+        datetime: new Date(Date.now()),
         ipfs: hash.id,
       })
       return resp
@@ -133,7 +132,6 @@ class DBStoreService {
 
     // TODO: store history and delete?
     if (existWiki) {
-      await activityRepository.save(createActivity(Status.UPDATED))
       existWiki.version = wiki.version
       existWiki.language = language
       existWiki.title = wiki.title
@@ -149,9 +147,9 @@ class DBStoreService {
       existWiki.ipfs = hash.id
       existWiki.transactionHash = hash.transactionHash
       await wikiRepository.save(existWiki)
+      await activityRepository.save(createActivity(Status.UPDATED))
       return true
     }
-    await activityRepository.save(createActivity(Status.CREATED))
 
     const newWiki = wikiRepository.create({
       id: wiki.id,
@@ -172,6 +170,9 @@ class DBStoreService {
     })
 
     await wikiRepository.save(newWiki)
+    // console.log(savedWiki)
+    await activityRepository.save(createActivity(Status.CREATED))
+
     return true
   }
 }


### PR DESCRIPTION
# new user profile issues

_Somehow the code isn't wrting the create date even when wiki is not existing yet, I changed the order to make sure wiki exists before activity is created._

## How should this be tested?

1. 
<img width="2056" alt="image" src="https://user-images.githubusercontent.com/67957533/176450518-17559330-d9d2-4463-a62b-f44dd10ce501.png">


## Notes or observations

_Existing users may still experience this [Issue 469](https://github.com/EveripediaNetwork/issues/issues/469), fresh users will get this update_

_@Emmanueldmlr Please note that older activity content create date will appear null, so these errors will still appear_
<img width="783" alt="image" src="https://user-images.githubusercontent.com/67957533/176452946-4914d823-6aff-4cc6-bd5e-c5f1c3eeb1bc.png">


## Linked issues

closes part of  https://github.com/EveripediaNetwork/issues/issues/469
