### PR TITLE
Fix for external link validation

### DIFF
--- a/src/Indexer/Validator/validator.service.spec.ts
+++ b/src/Indexer/Validator/validator.service.spec.ts
@@ -157,6 +157,15 @@ describe('PinResolver', () => {
     expect(await ipfsValidatorService.validate(wiki, true)).toEqual(result)
   })
 
+  it('should return status true for wiki content having expected URLs and parantheses in markdown title', async () => {
+    const wiki: ValidWiki = {
+      ...testWiki,
+      content:
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut rutrum tortor id fringilla ullamcorper. Mauris [VIDEO](https://www.youtube.com/fjdgjj) vitae enim turpis. Vivamus sed efficitur odio. Nullam consectetur malesuada purus, eget posuere massa. Morbi efficitur, mauris eget pharetra sollicitudin, nisl enim faucibus dolor, a semper risus leo suscipit ex. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Morbi dignissim suscipit augue vitae tempus. Nunc egestas dapibus elit eu auctor. Aenean ut sapien ante. Cras et lobortis dui.  \nLorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam ut convallis ante. Proin ex [VIDEO](https://www.vimeo.com/jsdfgjdf) ex, placerat eget aliquet ut, molestie ut nibh. Suspendisse malesuada metus quam, ut feugiat sapien feugiat vitae. Donec ac urna ligula. Integer vitae ipsum convallis metus mollis maximus. Maecenas risus felis, fringilla ut eleifend eu, egestas at leo.  \nCras quis sem sit amet eros posuere dictum sit amet at orci. Vestibulum nec efficitur nisi, vitae facilisis felis. Donec elementum sem ut varius volutpat. Suspendisse potenti. Nunc laoreet maximus facilisis. Suspendisse pellentesque pharetra nisi. Praesent pharetra lectus sit amet sapien facilisis molestie. Nam consequat commodo tellus suscipit maximus. Nullam id lorem augue. Donec eget lobortis diam. Curabitur eleifend elit sed consequat vestibulum. Nulla ante ligula, molestie sed ante ac, mattis sollicitudin nulla. Fusce id lobortis eros, et ultricies metus.  \nMauris odio nibh, maximus at magna sollicitudin, accumsan viverra felis. Nullam et metus pharetra, sagittis justo vitae, [IMAGE (IMAGE)](https://ipfs.everipedia.org/ipfs/jdfjf) tempor orci. Donec ut orci at mauris fermentum fringilla ac vitae ipsum. Duis quis turpis vitae sem dignissim porta at elementum tortor. Integer eget accumsan nisl. Morbi bibendum quam a tincidunt sagittis. Pellentesque mattis, ligula quis posuere bibendum, augue mauris porta dolor, vitae interdum urna massa non nunc. Maecenas faucibus pulvinar augue, non efficitur elit semper et. Aenean efficitur purus id est malesuada vulputate. Cras facilisis elit semper rutrum aliquam. Vestibulum lorem metus, rutrum eget facilisis in, vestibulum id tortor. Aliquam et imperdiet lectus. Sed ultrices sapien purus, suscipit aliquet diam rhoncus non. Ut quis diam risus. Integer laoreet tellus ligula, quis eleifend lorem placerat at.',
+    }
+    expect(await ipfsValidatorService.validate(wiki, true)).toEqual(result)
+  })
+
   it('should return status true for wiki content having weird links', async () => {
     const wiki: ValidWiki = {
       ...testWiki,

--- a/src/Indexer/Validator/validator.service.ts
+++ b/src/Indexer/Validator/validator.service.ts
@@ -119,7 +119,8 @@ class IPFSValidatorService {
       const markdownLinks = validatingWiki.content.match(/\[(.*?)\]\((.*?)\)/g)
       let isValid = true
       markdownLinks?.every(link => {
-        const url = link.match(/\((.*?)\)/g)?.[0].replace(/\(|\)/g, '')
+        const linkMatch = link.match(/\[(.*?)\]\((.*?)\)/)
+        const url = linkMatch?.[2]
         if (url && url.charAt(0) !== '#') {
           const validURLRecognizer = new RegExp(
             `^https?://(www\\.)?(${whitelistedDomains?.join('|')})`,


### PR DESCRIPTION
Fixes https://github.com/EveripediaNetwork/issues/issues/537

# Changes
- Fixes external link validation to accept all valid markdown link titles