### PR TITLE
External link validation to allow special widget links

### DIFF
--- a/src/Indexer/Validator/validator.service.spec.ts
+++ b/src/Indexer/Validator/validator.service.spec.ts
@@ -9,6 +9,8 @@ import IPFSValidatorService, { ValidatorResult } from './validator.service'
 process.env.UI_URL =
   'youtube.com/watch youtu.be vimeo.com alpha.everipedia.org/wiki ipfs.everipedia.org/ipfs'
 
+process.env.WIDGET_NAMES = 'YOUTUBE@VID'
+
 jest.mock('fs')
 
 describe('PinResolver', () => {

--- a/src/Indexer/Validator/validator.service.ts
+++ b/src/Indexer/Validator/validator.service.ts
@@ -103,14 +103,32 @@ class IPFSValidatorService {
       return false
     }
 
+    const isValidUrl = (urlString: string) => {
+      try {
+        return Boolean(new URL(urlString))
+      } catch (e) {
+        return false
+      }
+    }
+
     const checkExternalUrls = (validatingWiki: ValidWiki) => {
-      const uiLink = this.configService.get<string>('UI_URL')
-      const whitelistedDomains = uiLink?.split(' ')
+      const whitelistedDomains = this.configService
+        .get<string>('UI_URL')
+        ?.split(' ')
+      const WidgetNames =
+        this.configService.get<string>('WIDGET_NAMES')?.split(' ') || []
       const markdownLinks = validatingWiki.content.match(/\[(.*?)\]\((.*?)\)/g)
       let isValid = true
       markdownLinks?.every(link => {
         const linkMatch = link.match(/\[(.*?)\]\((.*?)\)/)
+        const text = linkMatch?.[1]
         const url = linkMatch?.[2]
+
+        if (text && url && WidgetNames.includes(text) && !isValidUrl(url)) {
+          isValid = true
+          return true
+        }
+
         if (url && url.charAt(0) !== '#') {
           const validURLRecognizer = new RegExp(
             `^https?://(www\\.)?(${whitelistedDomains?.join('|')})`,


### PR DESCRIPTION
## Changes
- allows custom widget links eg: `[YOUTUBE@VID](PHe0bXAIuk0)` to pass link validation

## Conditions for widget link
- name part of link syntax should have a fixed keyword like `YOUTUBE@VID`, `VIMEO@VID` etc. (currently only youtube vids are supported)
- the url part of the link syntax should be some ID but should not be a full URL 