### PR TITLE
Guard query

### DIFF
--- a/src/App/user.resolver.ts
+++ b/src/App/user.resolver.ts
@@ -86,6 +86,12 @@ class UserResolver {
     })
   }
 
+  @Query(() => Boolean)
+  @UseGuards(AuthGuard)
+  async isAdmin() {
+    return true
+  }
+
   @Mutation(() => User)
   @UseGuards(AuthGuard)
   async toggleUserStateById(@Args() args: UserStateArgs) {


### PR DESCRIPTION
# Guard query for admin

_Returns boolean or error, query must return true before admin ui is rendered_

## How should this be tested?

1. `{
  isAdmin
}`


## Linked issues

closes https://github.com/EveripediaNetwork/issues/issues/711
