### PR TITLE
Updates IQ Utils which fixes media errors with MediaType enum

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
-    "@everipedia/iq-utils": "^0.0.13",
+    "@everipedia/iq-utils": "^0.0.14",
     "@graphql-tools/utils": "^8.7.0",
     "@jest-mock/express": "^1.4.5",
     "@nestjs-modules/mailer": "^1.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -872,10 +872,10 @@
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/strings" "^5.6.1"
 
-"@everipedia/iq-utils@^0.0.13":
-  version "0.0.13"
-  resolved "https://registry.yarnpkg.com/@everipedia/iq-utils/-/iq-utils-0.0.13.tgz#6ac744a46150e39bd1c6210b25c56bb81ed2638f"
-  integrity sha512-VSBRz70nZGDzLdkwOFPxm6lLExGAlt2vEGpyQVQFZowk3dWbDjT2AZLPi8tPzd6P30IIH5G7LRgr8Es7iYDETw==
+"@everipedia/iq-utils@^0.0.14":
+  version "0.0.14"
+  resolved "https://registry.yarnpkg.com/@everipedia/iq-utils/-/iq-utils-0.0.14.tgz#4e5dbdbfac3a09f25e0c68c0705b4773edb3fdaf"
+  integrity sha512-Qk1IzJ3RpzwPMT46tNMVfTcsXSkOuXQNnX8sDejK5j1L4O1tX+tAC0BKszjLJQmFZDLaI2mmLTUh81hjz98UuA==
 
 "@fastify/accepts@^3.0.0":
   version "3.0.0"


### PR DESCRIPTION
Fixes https://github.com/EveripediaNetwork/issues/issues/959

# Changes
- updates iq-utils package to `0.0.14`.
	![CleanShot 2023-01-13 at 15 18 49@2x](https://user-images.githubusercontent.com/52039218/212290236-2c30bba8-c948-4330-a299-847181f7ca81.png)

- fixes graphql storing media type with DEFAULT instead of GALLERY

# Screenshots

### BEFORE FIX
<img width="1422" alt="image" src="https://user-images.githubusercontent.com/52039218/212287768-9ac5f475-4301-4fca-89be-8eb65949a436.png">


### AFTER FIX
<img width="1425" alt="image" src="https://user-images.githubusercontent.com/52039218/212287708-9209f5a9-5922-45e2-9c40-29516de69765.png">

