### PR TITLE
Add api for category total

### DIFF
--- a/src/App/pinJSONAndImage/pin.service.ts
+++ b/src/App/pinJSONAndImage/pin.service.ts
@@ -12,7 +12,6 @@ import USER_ACTIVITY_LIMIT from '../../globalVars'
 import PinJSONErrorWebhook from './webhookHandler/pinJSONErrorWebhook'
 import MetadataChangesService from '../../Indexer/Store/metadataChanges.service'
 
-
 @Injectable()
 class PinService {
   constructor(
@@ -95,9 +94,8 @@ class PinService {
         ...data,
       },
     }
-    const pinToPinata = async (
-      wikiContent: typeof payload,
-    ) => this.pinata().pinJSONToIPFS(wikiContent)
+    const pinToPinata = async (wikiContent: typeof payload) =>
+      this.pinata().pinJSONToIPFS(wikiContent)
 
     try {
       const res = await pinToPinata(payload)

--- a/src/App/stats.resolver.ts
+++ b/src/App/stats.resolver.ts
@@ -18,8 +18,6 @@ import Wiki from '../Database/Entities/wiki.entity'
 import PageviewsPerDay from '../Database/Entities/pageviewsPerPage.entity'
 import { CategoryArgs } from './wiki.dto'
 
-
-
 @ObjectType()
 export class Count {
   @Field(() => Int)
@@ -71,12 +69,6 @@ class IntervalArgs extends DateArgs {
 class UserArgs extends DateArgs {
   @Field(() => String)
   userId!: string
-}
-
-@ArgsType()
-class EditorArgs extends DateArgs {
-  @Field(() => Int)
-  status = 1
 }
 
 @UseInterceptors(SentryInterceptor)
@@ -166,13 +158,13 @@ class StatsResolver {
   }
 
   @Query(() => Count)
-  async editorCount(@Args() args: EditorArgs) {
+  async editorCount(@Args() args: DateArgs) {
     const repository = this.connection.getRepository(Activity)
     const response = await repository
       .createQueryBuilder('activity')
       .select(`Count(distinct activity."userId")`, 'amount')
       .leftJoin('wiki', 'w', 'w."id" = activity.wikiId')
-      .where(`w."hidden" = false AND type = '${args.status}'`)
+      .where(`w."hidden" = false`)
       .andWhere(
         `activity.datetime >= to_timestamp(${args.startDate}) AND activity.datetime <= to_timestamp(${args.endDate})`,
       )


### PR DESCRIPTION
# Category total

_`categoryTotal` returns `amount: number` for total number of entries in any category, cached for 1hr_

## How should this be tested?

1. <img width="2015" alt="image" src="https://user-images.githubusercontent.com/67957533/214079303-e3d92a5f-7fa6-42f4-ba1e-37bc067a037d.png">


## Linked issues
closes https://github.com/EveripediaNetwork/issues/issues/981
