### PR TITLE
Events tagging/revalidation

### DIFF
--- a/src/App/revalidatePage/revalidatePage.service.ts
+++ b/src/App/revalidatePage/revalidatePage.service.ts
@@ -85,6 +85,7 @@ export class RevalidatePageService {
           this.revalidate(Routes.ACTIVITY),
           this.revalidate(Routes.WIKI_PAGE, undefined, slug),
           this.revalidate(`/wiki/${slug}/history`),
+          this.revalidate(`/wiki/${slug}/events`),
         ])
       }
       if (page === RevalidateEndpoints.PROMOTE_WIKI) {

--- a/src/Indexer/Store/metadataChanges.service.ts
+++ b/src/Indexer/Store/metadataChanges.service.ts
@@ -104,6 +104,9 @@ class MetadataChangesService {
     if (oldWiki?.summary !== newWiki.summary) {
       blocksChanged.push('summary')
     }
+    if (oldWiki?.events !== newWiki.events) {
+      blocksChanged.push('events')
+    }
     const oldImgId = oldWiki.images && oldWiki.images[0].id
     const newImgId = newWiki.images && newWiki.images[0].id
 


### PR DESCRIPTION
# Event tagging on wiki history/revalidation

_Add `events` to DB history when changes are made and implement revalidation to `/wiki/<id>/events`_

## How should this be tested?

1. In dev

## Linked issues

closes https://github.com/EveripediaNetwork/issues/issues/1092
