### PR TITLE
Resolve activity created/updated string timestamps to db timestamps

### DIFF
--- a/src/App/Activities/activity.resolver.ts
+++ b/src/App/Activities/activity.resolver.ts
@@ -9,6 +9,7 @@ import {
 } from './dto/activity.dto'
 import { ArgsById } from '../utils/queryHelpers'
 import User from '../../Database/Entities/user.entity'
+import Wiki from '../../Database/Entities/wiki.entity'
 
 @Resolver(() => Activity)
 class ActivityResolver {
@@ -47,6 +48,17 @@ class ActivityResolver {
   @ResolveField(() => User, { name: 'user' })
   async forId(@Root() activity: Activity): Promise<User> {
     return { id: activity.userAddress } as User
+  }
+
+  @ResolveField(() => [Wiki])
+  async content(@Root() activity: Activity) {
+    const { content } = activity
+    const updatedContent = content.map((wiki) => ({
+      ...wiki,
+      created: activity.created_timestamp,
+      updated: activity.updated_timestamp,
+    }))
+    return updatedContent
   }
 }
 

--- a/src/App/Activities/activity.service.ts
+++ b/src/App/Activities/activity.service.ts
@@ -92,8 +92,21 @@ class ActivityService {
   async getActivitiesByUser(args: ActivityArgsByUser): Promise<Activity[]> {
     return (await this.repository())
       .createQueryBuilder('activity')
-      .leftJoin('wiki', 'w', 'w."id" = activity.wikiId')
-      .where('activity.userId = :id AND w."hidden" = false', {
+      .leftJoin('wiki', 'w', 'w."id" = activity.wikiId AND w."hidden" = false')
+      .select([
+        'activity.id',
+        'activity.type',
+        'activity.datetime',
+        'activity.userAddress',
+        'activity.wikiId',
+        'activity.languageId',
+        'activity.created_timestamp',
+        'activity.updated_timestamp',
+        'activity.block',
+        'activity.content',
+        'activity.ipfs',
+      ])
+      .where('activity.userAddress = :id', {
         id: args.userId,
       })
       .orderBy('activity.datetime', 'DESC')

--- a/src/Database/Entities/activity.entity.ts
+++ b/src/Database/Entities/activity.entity.ts
@@ -74,6 +74,14 @@ class Activity {
   @Index('idx_activity_datetime')
   datetime!: Date
 
+  @Field(() => GraphQLISODateTime, { nullable: true })
+  @Column('timestamp without time zone', { nullable: true })
+  created_timestamp!: Date
+
+  @Field(() => GraphQLISODateTime, { nullable: true })
+  @Column('timestamp without time zone', { nullable: true })
+  updated_timestamp!: Date
+
   @Field()
   @Column('varchar', { nullable: true })
   ipfs!: string

--- a/src/Database/Entities/wiki.entity.ts
+++ b/src/Database/Entities/wiki.entity.ts
@@ -24,7 +24,6 @@ import Metadata from './metadata.entity'
 import Media from './types/IMedia'
 import Image from './image.entity'
 import { Author } from './types/IUser'
-import dateMiddleware from './middlewares/wikiMiddleware'
 import LinkedWikis from './types/ILinkedWikis'
 import Events from './types/IEvents'
 
@@ -47,14 +46,12 @@ class Wiki {
   hidden!: boolean
 
   @Field(() => GraphQLISODateTime, {
-    middleware: [dateMiddleware],
     nullable: true,
   })
   @CreateDateColumn()
   created!: Date
 
   @Field(() => GraphQLISODateTime, {
-    middleware: [dateMiddleware],
     nullable: true,
   })
   @UpdateDateColumn()

--- a/src/Indexer/Store/store.service.ts
+++ b/src/Indexer/Store/store.service.ts
@@ -107,6 +107,8 @@ class DBStoreService {
         },
       ],
       userAddress: user.id,
+      created_timestamp: existWiki?.created,
+      updated_timestamp: existWiki?.updated,
       block: hash.block,
       language,
       datetime: new Date(Date.now()),


### PR DESCRIPTION
### Rather than have a middleware convert JSON string dates on demand/request, the timestamps are moved to separate columns to avoid calling new date on each request 

_In general, calling new Date() 30 times is likely to be slower than mapping fields in JavaScript for an array of length 30, assuming that the mapping function does not involve expensive operations._

_The reason for this is that creating a new Date object involves a significant amount of work, including parsing the input string, converting it to the correct time zone, and creating a new object instance. In contrast, mapping an array involves iterating over each element and performing some operation on it, which is generally less expensive than creating a new object._ 

