### PR TITLE
Modify params validaor with specs

### DIFF
--- a/src/App/utils/customValidator.ts
+++ b/src/App/utils/customValidator.ts
@@ -9,7 +9,7 @@ import {
 @ValidatorConstraint({ name: 'valid String', async: true })
 export default class ValidStringParams implements ValidatorConstraintInterface {
   async validate(text: string, args: ValidationArguments) {
-    return /^[a-zA-Z0-9 \/-]*$/.test(text)
+    return /^[a-zA-Z0-9()\/ -]*$/.test(text)
   }
 
   defaultMessage(args: ValidationArguments) {

--- a/src/App/utils/utils-spec/customValidator.spec.ts
+++ b/src/App/utils/utils-spec/customValidator.spec.ts
@@ -13,7 +13,8 @@ describe('ValidStringParams', () => {
   it('should fail validation for invalid string parameters', async () => {
     const validator = new ValidStringParams()
     const isValid = await validator.validate(
-      'Invalid String $pecial[] {Characters', null as any
+      'Invalid String $pecial[] {Characters',
+      null as any,
     )
     expect(isValid).toBe(false)
   })

--- a/src/App/utils/utils-spec/customValidator.spec.ts
+++ b/src/App/utils/utils-spec/customValidator.spec.ts
@@ -1,0 +1,20 @@
+import ValidStringParams from '../customValidator'
+
+describe('ValidStringParams', () => {
+  it('should pass validation for valid string parameters', async () => {
+    const validator = new ValidStringParams()
+    const isValid = await validator.validate(
+      'Valid String (with parentheses) ',
+      null as any,
+    )
+    expect(isValid).toBe(true)
+  })
+
+  it('should fail validation for invalid string parameters', async () => {
+    const validator = new ValidStringParams()
+    const isValid = await validator.validate(
+      'Invalid String $pecial[] {Characters', null as any
+    )
+    expect(isValid).toBe(false)
+  })
+})


### PR DESCRIPTION
# Param validator specs

_To accomodate use of brackets `()` in title

## How should this be tested?

1. `yarn test -- customValidator.spec.ts`

## Notes or observations

_jot down something here_

## Linked issues
parts of closes https://github.com/EveripediaNetwork/issues/issues/1342
