### PR TITLE
Right linking pages

### DIFF
--- a/src/App/marketCap/marketcapIds.ts
+++ b/src/App/marketCap/marketcapIds.ts
@@ -178,5 +178,5 @@ export const cryptocurrencyIds = [
   { coingeckoId: 'huobi-token', wikiId: 'huobi' },
   { coingeckoId: 'render-token', wikiId: 'rndr-token' },
   { coingeckoId: 'bitcoin-cash-sv', wikiId: 'bitcoin-sv' },
-  { coingeckoId: 'frax-ether', wikiId: 'frax-ether-frxeth-and-sfrxeth'},
+  { coingeckoId: 'frax-ether', wikiId: 'frax-ether-frxeth-and-sfrxeth' },
 ]

--- a/src/App/marketCap/marketcapIds.ts
+++ b/src/App/marketCap/marketcapIds.ts
@@ -176,4 +176,7 @@ export const cryptocurrencyIds = [
   { coingeckoId: 'whitebit', wikiId: 'whitebit-1' },
   { coingeckoId: 'pepe', wikiId: 'pepe-cryptocurrency' },
   { coingeckoId: 'huobi-token', wikiId: 'huobi' },
+  { coingeckoId: 'render-token', wikiId: 'rndr-token' },
+  { coingeckoId: 'bitcoin-cash-sv', wikiId: 'bitcoin-sv' },
+  { coingeckoId: 'frax-ether', wikiId: 'frax-ether-frxeth-and-sfrxeth'},
 ]


### PR DESCRIPTION
# Right-linking pages

_There are some pages that should be linked to the tokens on the rank pages , this is because those pages would be displaying NA on the rank pages , kindly link them for them to display the full information

fixes https://github.com/EveripediaNetwork/issues/issues/1431