### PR TITLE
Hi iq holders data

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "sitemap": "^7.1.1",
     "slugify": "^1.6.5",
     "typeorm": "^0.3.12",
+    "viem": "^1.6.0",
     "winston": "^3.8.2"
   },
   "devDependencies": {

--- a/src/App/HiIQHolders/hiIQHolder.module.ts
+++ b/src/App/HiIQHolders/hiIQHolder.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common'
+import { CacheModule, Module } from '@nestjs/common'
 import { ScheduleModule } from '@nestjs/schedule'
 import { HttpModule } from '@nestjs/axios'
 
@@ -9,11 +9,9 @@ import HiIQHolderService from './hiIQHolder.service'
   imports: [
     ScheduleModule.forRoot(),
     HttpModule,
+    CacheModule.register({ ttl: 3600 }),
   ],
-  providers: [
-    HiIQHolderService,
-    AlchemyNotifyService,
-  ],
-  exports: [ HiIQHolderService],
+  providers: [HiIQHolderService, AlchemyNotifyService],
+  exports: [HiIQHolderService],
 })
 export default class HiIQHolderModule {}

--- a/src/App/HiIQHolders/hiIQHolder.module.ts
+++ b/src/App/HiIQHolders/hiIQHolder.module.ts
@@ -2,16 +2,31 @@ import { CacheModule, Module } from '@nestjs/common'
 import { ScheduleModule } from '@nestjs/schedule'
 import { HttpModule } from '@nestjs/axios'
 
+import { TypeOrmModule } from '@nestjs/typeorm'
 import AlchemyNotifyService from '../../ExternalServices/alchemyNotify.service'
 import HiIQHolderService from './hiIQHolder.service'
+import HiIQHolderAddress from '../../Database/Entities/hiIQHolderAddress.entity'
+import HiIQHolder from '../../Database/Entities/hiIQHolder.entity'
+import HiIQHolderRepository from './hiIQHolder.repository'
+import HiIQHolderAddressRepository from './hiIQHolderAddress.repository'
 
 @Module({
   imports: [
+    TypeOrmModule.forFeature([HiIQHolderAddress, HiIQHolder]),
     ScheduleModule.forRoot(),
     HttpModule,
     CacheModule.register({ ttl: 3600 }),
   ],
-  providers: [HiIQHolderService, AlchemyNotifyService],
-  exports: [HiIQHolderService],
+  providers: [
+    HiIQHolderService,
+    HiIQHolderRepository,
+    HiIQHolderAddressRepository,
+    AlchemyNotifyService,
+  ],
+  exports: [
+    HiIQHolderService,
+    HiIQHolderRepository,
+    HiIQHolderAddressRepository,
+  ],
 })
 export default class HiIQHolderModule {}

--- a/src/App/HiIQHolders/hiIQHolder.module.ts
+++ b/src/App/HiIQHolders/hiIQHolder.module.ts
@@ -15,7 +15,6 @@ import HiIQHolderAddressRepository from './hiIQHolderAddress.repository'
     TypeOrmModule.forFeature([HiIQHolderAddress, HiIQHolder]),
     ScheduleModule.forRoot(),
     HttpModule,
-    CacheModule.register({ ttl: 3600 }),
   ],
   providers: [
     HiIQHolderService,

--- a/src/App/HiIQHolders/hiIQHolder.module.ts
+++ b/src/App/HiIQHolders/hiIQHolder.module.ts
@@ -8,6 +8,7 @@ import HiIQHolderAddress from '../../Database/Entities/hiIQHolderAddress.entity'
 import HiIQHolder from '../../Database/Entities/hiIQHolder.entity'
 import HiIQHolderRepository from './hiIQHolder.repository'
 import HiIQHolderAddressRepository from './hiIQHolderAddress.repository'
+import HiIQHoldersResolver from './hiIQHolder.resolver'
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import HiIQHolderAddressRepository from './hiIQHolderAddress.repository'
   ],
   providers: [
     HiIQHolderService,
+    HiIQHoldersResolver,
     HiIQHolderRepository,
     HiIQHolderAddressRepository,
   ],

--- a/src/App/HiIQHolders/hiIQHolder.module.ts
+++ b/src/App/HiIQHolders/hiIQHolder.module.ts
@@ -1,9 +1,8 @@
-import { CacheModule, Module } from '@nestjs/common'
+import { Module } from '@nestjs/common'
 import { ScheduleModule } from '@nestjs/schedule'
 import { HttpModule } from '@nestjs/axios'
 
 import { TypeOrmModule } from '@nestjs/typeorm'
-import AlchemyNotifyService from '../../ExternalServices/alchemyNotify.service'
 import HiIQHolderService from './hiIQHolder.service'
 import HiIQHolderAddress from '../../Database/Entities/hiIQHolderAddress.entity'
 import HiIQHolder from '../../Database/Entities/hiIQHolder.entity'
@@ -20,7 +19,6 @@ import HiIQHolderAddressRepository from './hiIQHolderAddress.repository'
     HiIQHolderService,
     HiIQHolderRepository,
     HiIQHolderAddressRepository,
-    AlchemyNotifyService,
   ],
   exports: [
     HiIQHolderService,

--- a/src/App/HiIQHolders/hiIQHolder.module.ts
+++ b/src/App/HiIQHolders/hiIQHolder.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common'
+import { ScheduleModule } from '@nestjs/schedule'
+import { HttpModule } from '@nestjs/axios'
+
+import AlchemyNotifyService from '../../ExternalServices/alchemyNotify.service'
+import HiIQHolderService from './hiIQHolder.service'
+
+@Module({
+  imports: [
+    ScheduleModule.forRoot(),
+    HttpModule,
+  ],
+  providers: [
+    HiIQHolderService,
+    AlchemyNotifyService,
+  ],
+  exports: [ HiIQHolderService],
+})
+export default class HiIQHolderModule {}

--- a/src/App/HiIQHolders/hiIQHolder.repository.ts
+++ b/src/App/HiIQHolders/hiIQHolder.repository.ts
@@ -25,16 +25,17 @@ class HiIQHolderRepository extends Repository<HiIQHolder> {
             WHERE (row_num - 1) % $1 = 0
             ORDER BY day
             OFFSET $2
-            LIMIT $2;
+            LIMIT $3;
         `,
         [args.interval, args.offset, args.limit],
       )
     }
-    return this.find({
-      select: ['amount', 'day'],
-      take: args.limit,
-      skip: args.offset,
-    })
+    return this.createQueryBuilder('hi_iq_holder')
+      .select('amount')
+      .addSelect('day')
+      .offset(args.offset)
+      .limit(args.limit)
+      .getRawMany()
   }
 }
 

--- a/src/App/HiIQHolders/hiIQHolder.repository.ts
+++ b/src/App/HiIQHolders/hiIQHolder.repository.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@nestjs/common'
+import { DataSource, Repository } from 'typeorm'
+import HiIQHolder from '../../Database/Entities/hiIQHolder.entity'
+import { IntervalByDays } from '../utils/queryHelpers'
+import HiIQHolderArgs from './hiIQHolders.dto'
+
+@Injectable()
+class HiIQHolderRepository extends Repository<HiIQHolder> {
+  constructor(private dataSource: DataSource) {
+    super(HiIQHolder, dataSource.createEntityManager())
+  }
+
+  async getHiIQHoldersCount(args: HiIQHolderArgs): Promise<HiIQHolder[]> {
+    if (args.interval !== IntervalByDays.DAY) {
+      return this.query(
+        `
+            WITH RankedData AS (
+            SELECT
+                amount, day,
+                ROW_NUMBER() OVER (ORDER BY day) AS row_num
+            FROM hi_iq_holder
+            )
+            SELECT amount, day
+            FROM RankedData
+            WHERE (row_num - 1) % $1 = 0
+            ORDER BY day
+            OFFSET $2
+            LIMIT $2;
+        `,
+        [args.interval, args.offset, args.limit],
+      )
+    }
+    return this.find({
+      select: ['amount', 'day'],
+      take: args.limit,
+      skip: args.offset,
+    })
+  }
+}
+
+export default HiIQHolderRepository

--- a/src/App/HiIQHolders/hiIQHolder.resolver.ts
+++ b/src/App/HiIQHolders/hiIQHolder.resolver.ts
@@ -1,0 +1,18 @@
+import { Args, Query, Resolver } from '@nestjs/graphql'
+import HiIQHolder from '../../Database/Entities/hiIQHolder.entity'
+import HiIQHolderRepository from './hiIQHolder.repository'
+import HiIQHolderArgs from './hiIQHolders.dto'
+
+
+
+@Resolver(() => HiIQHolder)
+class HiIQHoldersResolver {
+  constructor(private hiIQHoldersRepository: HiIQHolderRepository) {}
+
+  @Query(() => [HiIQHolder], { name: 'hiIQHolders' })
+  async hiIQHolders(@Args() args: HiIQHolderArgs) {
+    return this.hiIQHoldersRepository.getHiIQHoldersCount(args)
+  }
+}
+
+export default HiIQHoldersResolver

--- a/src/App/HiIQHolders/hiIQHolder.resolver.ts
+++ b/src/App/HiIQHolders/hiIQHolder.resolver.ts
@@ -3,8 +3,6 @@ import HiIQHolder from '../../Database/Entities/hiIQHolder.entity'
 import HiIQHolderRepository from './hiIQHolder.repository'
 import HiIQHolderArgs from './hiIQHolders.dto'
 
-
-
 @Resolver(() => HiIQHolder)
 class HiIQHoldersResolver {
   constructor(private hiIQHoldersRepository: HiIQHolderRepository) {}

--- a/src/App/HiIQHolders/hiIQHolder.service.ts
+++ b/src/App/HiIQHolders/hiIQHolder.service.ts
@@ -113,13 +113,15 @@ class HiIQHolderService {
     const count = await this.iqHolders.createQueryBuilder().getCount()
     const newDay = next ? new Date(next * 1000).toISOString() : '2021-06-01' // contract start date
     const existCount = await this.repo.findOneBy({
-      day: newDay,
+      day: new Date(newDay),
     })
 
     if (!existCount) {
       const totalHolders = this.repo.create({
         amount: count,
         day: newDay,
+        created: newDay,
+        updated: newDay,
       })
       await this.repo.save(totalHolders)
       console.log(`hiIQ holder Count for day ${newDay} saved 📈`)

--- a/src/App/HiIQHolders/hiIQHolder.service.ts
+++ b/src/App/HiIQHolders/hiIQHolder.service.ts
@@ -60,7 +60,7 @@ class HiIQHolderService {
     await stopJob(this.repo, job)
 
     // if (firstLevelNodeProcess()) {
-      await this.indexHIIQHolders()
+    await this.indexHIIQHolders()
     // }
   }
 

--- a/src/App/HiIQHolders/hiIQHolder.service.ts
+++ b/src/App/HiIQHolders/hiIQHolder.service.ts
@@ -1,4 +1,3 @@
-
 import { CACHE_MANAGER, Inject, Injectable } from '@nestjs/common'
 import { Cache } from 'cache-manager'
 import { Cron, CronExpression } from '@nestjs/schedule'
@@ -6,9 +5,9 @@ import { HttpService } from '@nestjs/axios'
 import { ConfigService } from '@nestjs/config'
 import { ethers } from 'ethers'
 
+export const hiIQCOntract = '0x1bF5457eCAa14Ff63CC89EFd560E251e814E16Ba'
 
-const hiIQCOntract = '0x1bF5457eCAa14Ff63CC89EFd560E251e814E16Ba'
-const enum HiIQMethods {
+export enum HiIQMethods {
   CREATE_LOCK = '0x65fc3873',
   WITHDRAW = '0x3ccfd60b',
 }
@@ -52,23 +51,22 @@ class HiIQHolderService {
 
     const provider = new ethers.providers.JsonRpcProvider(this.provider())
 
-
     logs.forEach(async (log: any) => {
       try {
         const dp = await provider.getTransaction(log.transactionHash)
 
         if (dp.data.startsWith(HiIQMethods.CREATE_LOCK)) {
-            const existHolder = await this.checExistingHolders(dp.from)
-            if(!existHolder) {
-                // insert record in list of holders table
-            }
+          const existHolder = await this.checExistingHolders(dp.from)
+          if (!existHolder) {
+            // insert record in list of holders table
+          }
           console.log(dp)
         }
         if (dp.data.startsWith(HiIQMethods.WITHDRAW)) {
-            const existHolder = await this.checExistingHolders(dp.from)
-            if(existHolder) {
-                // remove address from db
-            }
+          const existHolder = await this.checExistingHolders(dp.from)
+          if (existHolder) {
+            // remove address from db
+          }
           console.log(dp)
         }
       } catch (e) {

--- a/src/App/HiIQHolders/hiIQHolder.service.ts
+++ b/src/App/HiIQHolders/hiIQHolder.service.ts
@@ -1,30 +1,99 @@
-import { Injectable } from '@nestjs/common'
+
+import { CACHE_MANAGER, Inject, Injectable } from '@nestjs/common'
+import { Cache } from 'cache-manager'
 import { Cron, CronExpression } from '@nestjs/schedule'
 import { HttpService } from '@nestjs/axios'
-import { createPublicClient, http, parseAbiItem, parseUnits } from 'viem'
-import { mainnet } from 'viem/chains'
 import { ConfigService } from '@nestjs/config'
+import { ethers } from 'ethers'
+
+
+const hiIQCOntract = '0x1bF5457eCAa14Ff63CC89EFd560E251e814E16Ba'
+const enum HiIQMethods {
+  CREATE_LOCK = '0x65fc3873',
+  WITHDRAW = '0x3ccfd60b',
+}
 
 @Injectable()
 class HiIQHolderService {
   constructor(
     private configService: ConfigService,
     private httpService: HttpService,
+    @Inject(CACHE_MANAGER) private cacheManager: Cache,
   ) {}
+
+  private provider(): string {
+    return this.configService.get<string>('PROVIDER_NETWORK') as string
+  }
 
   private etherScanApiKey(): string {
     return this.configService.get<string>('etherScanApiKey') as string
   }
 
+  async lastHolderRecord(): Promise<Date | number> {
+    return 2
+  }
+
+  async checExistingHolders(address: string): Promise<any | null> {
+    return null
+  }
+
   @Cron(CronExpression.EVERY_5_SECONDS, {
     name: 'IndexOldHiIQHolders',
   })
-  async getLogs() {
-    const time = 1691711940 // 10 at 11:59
-    const newTime = 1691625540 // 9 at 11:59
+  async getLogw() {
+    // const oneDayInSeconds = 86400
+    const stk = 'startTimestamp'
+    const etk = 'endTimestamp'
+    const previous: number | undefined = await this.cacheManager.get(stk)
+    // const previous = await this.lastHolderCount().day
+    const next: number | undefined = await this.cacheManager.get(etk)
+
+    const logs = await this.oldLogs(previous as number, next as number)
+
+    const provider = new ethers.providers.JsonRpcProvider(this.provider())
+
+
+    logs.forEach(async (log: any) => {
+      try {
+        const dp = await provider.getTransaction(log.transactionHash)
+
+        if (dp.data.startsWith(HiIQMethods.CREATE_LOCK)) {
+            const existHolder = await this.checExistingHolders(dp.from)
+            if(!existHolder) {
+                // insert record in list of holders table
+            }
+          console.log(dp)
+        }
+        if (dp.data.startsWith(HiIQMethods.WITHDRAW)) {
+            const existHolder = await this.checExistingHolders(dp.from)
+            if(existHolder) {
+                // remove address from db
+            }
+          console.log(dp)
+        }
+      } catch (e) {
+        console.log(e)
+      }
+    })
+    // set count of holders for that day using next as upper limit
+  }
+
+  async oldLogs(previous: number, next: number) {
+    const oneDayInSeconds = 86400
+
+    const startTimestamp = 1622541600 // contract creation 2021-06-01
+    let endTimestamp = startTimestamp + oneDayInSeconds
+
+    const stk = 'startTimestamp'
+    const etk = 'endTimestamp'
+
     const key = this.etherScanApiKey()
-    const url1 = `https://api.etherscan.io/api?module=block&action=getblocknobytime&timestamp=${time}&closest=before&apikey=${key}`
-    const url2 = `https://api.etherscan.io/api?module=block&action=getblocknobytime&timestamp=${newTime}&closest=before&apikey=${key}`
+    const url1 = `https://api.etherscan.io/api?module=block&action=getblocknobytime&timestamp=${
+      previous || startTimestamp
+    }&closest=before&apikey=${key}`
+    const url2 = `https://api.etherscan.io/api?module=block&action=getblocknobytime&timestamp=${
+      next || endTimestamp
+    }&closest=before&apikey=${key}`
 
     let blockNumberForQuery1
     let blockNumberForQuery2
@@ -36,41 +105,29 @@ class HiIQHolderService {
     } catch (e: any) {
       console.error('Error requesting block number', e.data)
     }
+    console.log('blocknumber', blockNumberForQuery1, blockNumberForQuery2)
 
-    const publicClient = createPublicClient({
-      chain: mainnet,
-      transport: http(),
-    })
+    const logsFor1Day = `https://api.etherscan.io/api?module=logs&action=getLogs&address=${hiIQCOntract}&fromBlock=${blockNumberForQuery1}&toBlock=${blockNumberForQuery2}&page=1&offset=1000&apikey=${key}`
 
-    if (BigInt(blockNumberForQuery2) && BigInt(blockNumberForQuery1)) {
-      const logs = await publicClient.getLogs({
-        address: '0x1bF5457eCAa14Ff63CC89EFd560E251e814E16Ba',
-        event: parseAbiItem(
-          'event Deposit(address indexed provider, uint256 value,uint256 locktime, int128 type, uint256 ts)',
-        ),
-        fromBlock: parseUnits(blockNumberForQuery1, 1),
-        toBlock: parseUnits(blockNumberForQuery2, 1),
-      })
-      console.log(logs)
+    let logs
+    try {
+      const resp = await this.httpService.get(logsFor1Day).toPromise()
+      logs = resp?.data.result
+      //   console.log(resp?.data.result)
+    } catch (e: any) {
+      console.error('Error requesting log data', e)
     }
-    // const cleanData = []
-    // for (const log of logs) {
-    //   const address = log.args.provider
-    //   const { data } = log
-    //   const { topics } = log
-    //   const decodedData = decodeEventLog({
-    //     abi: hiIQAbi,
-    //     data,
-    //     topics,
-    //   })
-    //   const block = await publicClient.getBlock({
-    //     blockNumber: log.blockNumber as bigint,
-    //   })
-    //   const timestamp = new Date(Number(block.timestamp * 1000n)).toUTCString()
-    //   cleanData.push({ address, decodedData, timestamp })
-    // }
-
-    // return cleanData
+    await this.cacheManager.del(stk)
+    await this.cacheManager.del(etk)
+    if (!previous && !next) {
+      await this.cacheManager.set(stk, endTimestamp)
+      await this.cacheManager.set(etk, (endTimestamp += oneDayInSeconds))
+    } else {
+      const e = next + oneDayInSeconds
+      await this.cacheManager.set(stk, next)
+      await this.cacheManager.set(etk, e)
+    }
+    return logs
   }
 }
 export default HiIQHolderService

--- a/src/App/HiIQHolders/hiIQHolder.service.ts
+++ b/src/App/HiIQHolders/hiIQHolder.service.ts
@@ -59,9 +59,9 @@ class HiIQHolderService {
     const job = this.schedulerRegistry.getCronJob('storeHiIQHolderCount')
     await stopJob(this.repo, job)
 
-    // if (firstLevelNodeProcess()) {
-    await this.indexHIIQHolders()
-    // }
+    if (firstLevelNodeProcess()) {
+      await this.indexHIIQHolders()
+    }
   }
 
   async indexHIIQHolders() {

--- a/src/App/HiIQHolders/hiIQHolder.service.ts
+++ b/src/App/HiIQHolders/hiIQHolder.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common'
-import { Cron, CronExpression, } from '@nestjs/schedule'
+import { Cron, CronExpression } from '@nestjs/schedule'
 import { HttpService } from '@nestjs/axios'
 import { createPublicClient, http, parseAbiItem, parseUnits } from 'viem'
 import { mainnet } from 'viem/chains'

--- a/src/App/HiIQHolders/hiIQHolder.service.ts
+++ b/src/App/HiIQHolders/hiIQHolder.service.ts
@@ -1,0 +1,76 @@
+import { Injectable } from '@nestjs/common'
+import { Cron, CronExpression, } from '@nestjs/schedule'
+import { HttpService } from '@nestjs/axios'
+import { createPublicClient, http, parseAbiItem, parseUnits } from 'viem'
+import { mainnet } from 'viem/chains'
+import { ConfigService } from '@nestjs/config'
+
+@Injectable()
+class HiIQHolderService {
+  constructor(
+    private configService: ConfigService,
+    private httpService: HttpService,
+  ) {}
+
+  private etherScanApiKey(): string {
+    return this.configService.get<string>('etherScanApiKey') as string
+  }
+
+  @Cron(CronExpression.EVERY_5_SECONDS, {
+    name: 'IndexOldHiIQHolders',
+  })
+  async getLogs() {
+    const time = 1691711940 // 10 at 11:59
+    const newTime = 1691625540 // 9 at 11:59
+    const key = this.etherScanApiKey()
+    const url1 = `https://api.etherscan.io/api?module=block&action=getblocknobytime&timestamp=${time}&closest=before&apikey=${key}`
+    const url2 = `https://api.etherscan.io/api?module=block&action=getblocknobytime&timestamp=${newTime}&closest=before&apikey=${key}`
+
+    let blockNumberForQuery1
+    let blockNumberForQuery2
+    try {
+      const response1 = await this.httpService.get(url1).toPromise()
+      const response2 = await this.httpService.get(url2).toPromise()
+      blockNumberForQuery1 = response1?.data.result
+      blockNumberForQuery2 = response2?.data.result
+    } catch (e: any) {
+      console.error('Error requesting block number', e.data)
+    }
+
+    const publicClient = createPublicClient({
+      chain: mainnet,
+      transport: http(),
+    })
+
+    if (BigInt(blockNumberForQuery2) && BigInt(blockNumberForQuery1)) {
+      const logs = await publicClient.getLogs({
+        address: '0x1bF5457eCAa14Ff63CC89EFd560E251e814E16Ba',
+        event: parseAbiItem(
+          'event Deposit(address indexed provider, uint256 value,uint256 locktime, int128 type, uint256 ts)',
+        ),
+        fromBlock: parseUnits(blockNumberForQuery1, 1),
+        toBlock: parseUnits(blockNumberForQuery2, 1),
+      })
+      console.log(logs)
+    }
+    // const cleanData = []
+    // for (const log of logs) {
+    //   const address = log.args.provider
+    //   const { data } = log
+    //   const { topics } = log
+    //   const decodedData = decodeEventLog({
+    //     abi: hiIQAbi,
+    //     data,
+    //     topics,
+    //   })
+    //   const block = await publicClient.getBlock({
+    //     blockNumber: log.blockNumber as bigint,
+    //   })
+    //   const timestamp = new Date(Number(block.timestamp * 1000n)).toUTCString()
+    //   cleanData.push({ address, decodedData, timestamp })
+    // }
+
+    // return cleanData
+  }
+}
+export default HiIQHolderService

--- a/src/App/HiIQHolders/hiIQHolderAddress.repository.ts
+++ b/src/App/HiIQHolders/hiIQHolderAddress.repository.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@nestjs/common'
+import { DataSource, Repository } from 'typeorm'
+import HiIQHolderAddress from '../../Database/Entities/hiIQHolderAddress.entity'
+
+@Injectable()
+class HiIQHolderAddressRepository extends Repository<HiIQHolderAddress> {
+  constructor(private dataSource: DataSource) {
+    super(HiIQHolderAddress, dataSource.createEntityManager())
+  }
+}
+
+export default HiIQHolderAddressRepository

--- a/src/App/HiIQHolders/hiIQHolders.dto.ts
+++ b/src/App/HiIQHolders/hiIQHolders.dto.ts
@@ -1,0 +1,15 @@
+import { ArgsType, Field, Int } from '@nestjs/graphql'
+import { Min, Max } from 'class-validator'
+import { IntervalByDays } from '../utils/queryHelpers'
+import PaginationArgs from '../pagination.args'
+
+@ArgsType()
+export default class HiIQHolderArgs extends PaginationArgs {
+  @Field(() => IntervalByDays)
+  interval = IntervalByDays.DAY
+
+  @Field(() => Int)
+  @Min(1)
+  @Max(365)
+  limit = 182
+}

--- a/src/App/StakedIQ/stakedIQ.utils.ts
+++ b/src/App/StakedIQ/stakedIQ.utils.ts
@@ -22,16 +22,6 @@ export const existRecord = async (
     .getOne()
 }
 
-// export const leastRecordByDate = async (
-//   repo: Repository<StakedIQ | Treasury>,
-// ): Promise<Partial<StakedIQ>[] | Partial<Treasury>[] | []> =>
-//   repo.find({
-//     order: {
-//       updated: 'DESC',
-//     },
-//     take: 1,
-//   })
-
 export const leastRecordByDate = async <T extends ObjectLiteral>(
   repo: Repository<T>,
 ): Promise<Partial<T>[]> =>
@@ -62,21 +52,6 @@ export const insertOldData = async (
   await entity.save(previousData)
   console.log(`Previous ${entity.metadata.targetName} data saved`)
 }
-
-// export const stopJob = async (
-//   repo: Repository<StakedIQ | Treasury>,
-//   job: CronJob,
-// ) => {
-//   const oldRecord = await leastRecordByDate(repo)
-
-//   if (oldRecord.length > 0) {
-//     const oldDate = dateOnly(oldRecord[0]?.created as Date)
-//     const presentDate = dateOnly(todayMidnightDate)
-//     if (oldDate === presentDate) {
-//       job.stop()
-//     }
-//   }
-// }
 
 interface EntityWithCreated {
   created?: Date

--- a/src/App/StakedIQ/stakedIQ.utils.ts
+++ b/src/App/StakedIQ/stakedIQ.utils.ts
@@ -27,7 +27,7 @@ export const leastRecordByDate = async <T extends ObjectLiteral>(
 ): Promise<Partial<T>[]> =>
   repo.find({
     order: {
-      updated: 'ASC',
+      updated: 'DESC',
     } as any,
     take: 1,
   })

--- a/src/App/app.module.ts
+++ b/src/App/app.module.ts
@@ -57,6 +57,7 @@ import BrainPassModule from './BrainPass/brainPass.module'
 import ActivityModule from './Activities/activity.module'
 import TreasuryModule from './Treasury/treasury.module'
 import StakedIQModule from './StakedIQ/stakedIQ.module'
+import HiIQHolderModule from './HiIQHolders/hiIQHolder.module'
 // instannul ignore next
 @Module({
   imports: [
@@ -96,7 +97,8 @@ import StakedIQModule from './StakedIQ/stakedIQ.module'
     ActivityModule,
     IndexerWebhookModule,
     TreasuryModule, 
-    StakedIQModule
+    StakedIQModule,
+    HiIQHolderModule,
   ],
   controllers: [],
   providers: [

--- a/src/App/utils/queryHelpers.ts
+++ b/src/App/utils/queryHelpers.ts
@@ -24,11 +24,11 @@ export enum Direction {
 }
 
 export enum IntervalByDays {
-    DAY = 1,
-    WEEK = 7,
-    MONTH = 30,
-    NINETY_DAYS = 90,
-    YEAR = 365
+  DAY = 1,
+  WEEK = 7,
+  MONTH = 30,
+  NINETY_DAYS = 90,
+  YEAR = 365,
 }
 
 @ArgsType()

--- a/src/App/utils/queryHelpers.ts
+++ b/src/App/utils/queryHelpers.ts
@@ -41,6 +41,7 @@ export class ArgsById {
 registerEnumType(OrderBy, { name: 'OrderBy' })
 registerEnumType(Direction, { name: 'Direction' })
 registerEnumType(ActivityType, { name: 'ActivityType' })
+registerEnumType(IntervalByDays, { name: 'IntervalByDays' })
 
 export const orderWikis = (order: OrderBy, direction: Direction) => {
   let sortValue = {}

--- a/src/App/utils/queryHelpers.ts
+++ b/src/App/utils/queryHelpers.ts
@@ -23,6 +23,14 @@ export enum Direction {
   DESC = 'DESC',
 }
 
+export enum IntervalByDays {
+    DAY = 1,
+    WEEK = 7,
+    MONTH = 30,
+    NINETY_DAYS = 90,
+    YEAR = 365
+}
+
 @ArgsType()
 export class ArgsById {
   @Field(() => String)

--- a/src/Database/Entities/hiIQHolder.entity.ts
+++ b/src/Database/Entities/hiIQHolder.entity.ts
@@ -20,7 +20,7 @@ class HiIQHolder {
 
   @Field(() => GraphQLISODateTime)
   @Column('date')
-  day!: string
+  day!: Date
 
   @Field(() => GraphQLISODateTime)
   @CreateDateColumn()

--- a/src/Database/Entities/hiIQHolder.entity.ts
+++ b/src/Database/Entities/hiIQHolder.entity.ts
@@ -1,0 +1,34 @@
+import { Field, GraphQLISODateTime, ID, Int, ObjectType } from '@nestjs/graphql'
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm'
+
+@ObjectType()
+@Entity()
+class HiIQHolder {
+  @Field(() => ID)
+  @PrimaryGeneratedColumn()
+  id!: number
+
+  @Field(() => Int)
+  @Column('integer')
+  amount!: number
+
+  @Field(() => GraphQLISODateTime)
+  @Column('date')
+  day!: string
+
+  @Field(() => GraphQLISODateTime)
+  @CreateDateColumn()
+  created!: Date
+
+  @Field(() => GraphQLISODateTime)
+  @UpdateDateColumn()
+  updated!: Date
+}
+
+export default HiIQHolder

--- a/src/Database/Entities/hiIQHolderAddress.entity.ts
+++ b/src/Database/Entities/hiIQHolderAddress.entity.ts
@@ -1,0 +1,32 @@
+import { Field, GraphQLISODateTime, ID, ObjectType } from '@nestjs/graphql'
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm'
+
+@ObjectType()
+@Entity()
+class HiIQHolderAddress {
+  @Field(() => ID)
+  @PrimaryGeneratedColumn()
+  id!: number
+
+  @Field(() => String)
+  @Column('varchar', {
+    unique: true,
+  })
+  address!: string
+
+  @Field(() => GraphQLISODateTime)
+  @CreateDateColumn()
+  created!: Date
+
+  @Field(() => GraphQLISODateTime)
+  @UpdateDateColumn()
+  updated!: Date
+}
+
+export default HiIQHolderAddress

--- a/src/Database/database.module.ts
+++ b/src/Database/database.module.ts
@@ -16,6 +16,8 @@ import Feedback from './Entities/feedback.entity'
 import BrainPass from './Entities/brainPass.entity'
 import Treasury from './Entities/treasury.entity'
 import StakedIQ from './Entities/stakedIQ.entity'
+import HiIQHolderAddress from './Entities/hiIQHolderAddress.entity'
+import HiIQHolder from './Entities/hiIQHolder.entity'
 
 @Module({
   imports: [
@@ -44,6 +46,8 @@ import StakedIQ from './Entities/stakedIQ.entity'
           BrainPass,
           Treasury,
           StakedIQ,
+          HiIQHolder,
+          HiIQHolderAddress
         ],
         synchronize: true,
         keepConnectionAlive: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@adraffy/ens-normalize@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.9.0.tgz#223572538f6bea336750039bb43a4016dcc8182d"
+  integrity sha512-iowxq3U30sghZotgl4s/oJRci6WPBfNO5YYgk2cIOMCHr3LeGPcsZjCEr+33Q4N+oV3OABDAtA+pyvWjbvBifQ==
+
 "@ampproject/remapping@^2.1.0":
   version "2.1.2"
   resolved "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz"
@@ -1788,10 +1793,29 @@
   dependencies:
     glob "7.1.7"
 
-"@noble/hashes@^1.1.2":
+"@noble/curves@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.1.0.tgz#f13fc667c89184bc04cccb9b11e8e7bae27d8c3d"
+  integrity sha512-091oBExgENk/kGj3AZmtBDMpxQPDtxQABR2B9lb1JbVTs6ytdzZNwvhxQ4MWasRNEzlbEH8jCWFCwhF/Obj5AA==
+  dependencies:
+    "@noble/hashes" "1.3.1"
+
+"@noble/curves@~1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.0.0.tgz#e40be8c7daf088aaf291887cbc73f43464a92932"
+  integrity sha512-2upgEu0iLiDVDZkNLeFV2+ht0BAVgQnEmCk6JsOch9Rp8xfkMCbvbAZlA2pBHQc73dbl+vFOXfqkf4uemdn0bw==
+  dependencies:
+    "@noble/hashes" "1.3.0"
+
+"@noble/hashes@1.3.0", "@noble/hashes@^1.1.2":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.0.tgz#085fd70f6d7d9d109671090ccae1d3bec62554a1"
   integrity sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==
+
+"@noble/hashes@1.3.1", "@noble/hashes@~1.3.0":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.1.tgz#8831ef002114670c603c458ab8b11328406953a9"
+  integrity sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==
 
 "@noble/secp256k1@^1.7.1":
   version "1.7.1"
@@ -2015,6 +2039,28 @@
   version "1.1.0"
   resolved "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.1.0.tgz"
   integrity sha512-JLo+Y592QzIE+q7Dl2pMUtt4q8SKYI5jDrZxrozEQxnGVOyYE+GWK9eLkwTaeN9DDctlaRAQ3TBmzZ1qdLE30A==
+
+"@scure/base@~1.1.0":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.1.tgz#ebb651ee52ff84f420097055f4bf46cfba403938"
+  integrity sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==
+
+"@scure/bip32@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.3.0.tgz#6c8d980ef3f290987736acd0ee2e0f0d50068d87"
+  integrity sha512-bcKpo1oj54hGholplGLpqPHRbIsnbixFtc06nwuNM5/dwSXOq/AAYoIBRsBmnZJSdfeNW5rnff7NTAz3ZCqR9Q==
+  dependencies:
+    "@noble/curves" "~1.0.0"
+    "@noble/hashes" "~1.3.0"
+    "@scure/base" "~1.1.0"
+
+"@scure/bip39@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.2.0.tgz#a207e2ef96de354de7d0002292ba1503538fc77b"
+  integrity sha512-SX/uKq52cuxm4YFXWFaVByaSHJh2w3BnokVSeUJVCv6K7WulT9u2BuNRBhuFl8vAuYnzx9bEu9WgpcNYTrYieg==
+  dependencies:
+    "@noble/hashes" "~1.3.0"
+    "@scure/base" "~1.1.0"
 
 "@selderee/plugin-htmlparser2@^0.6.0":
   version "0.6.0"
@@ -2780,6 +2826,13 @@
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.3.tgz#a136f83b0758698df454e328759dbd3d44555311"
   integrity sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g==
 
+"@types/ws@^8.5.4":
+  version "8.5.5"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.5.tgz#af587964aa06682702ee6dcbc7be41a80e4b28eb"
+  integrity sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/yargs-parser@*":
   version "20.2.1"
   resolved "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.1.tgz"
@@ -2878,6 +2931,11 @@
   dependencies:
     "@typescript-eslint/types" "5.13.0"
     eslint-visitor-keys "^3.0.0"
+
+"@wagmi/chains@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@wagmi/chains/-/chains-1.6.0.tgz#eb992ad28dbaaab729b5bcab3e5b461e8a035656"
+  integrity sha512-5FRlVxse5P4ZaHG3GTvxwVANSmYJas1eQrTBHhjxVtqXoorm0aLmCHbhmN8Xo1yu09PaWKlleEvfE98yH4AgIw==
 
 "@wagmi/chains@~0.2.11":
   version "0.2.15"
@@ -3024,6 +3082,11 @@ abbrev@1, abbrev@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
+
+abitype@0.9.3:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/abitype/-/abitype-0.9.3.tgz#294d25288ee683d72baf4e1fed757034e3c8c277"
+  integrity sha512-dz4qCQLurx97FQhnb/EIYTk/ldQ+oafEDUqC0VVIeQS1Q48/YWt/9YNfMmp9SLFqN41ktxny3c8aYxHjmFIB/w==
 
 abitype@~0.7.1:
   version "0.7.1"
@@ -7218,7 +7281,7 @@ isomorphic-unfetch@^3.0.0:
     node-fetch "^2.6.1"
     unfetch "^4.2.0"
 
-isomorphic-ws@^5.0.0:
+isomorphic-ws@5.0.0, isomorphic-ws@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz#e5529148912ecb9b451b46ed44d53dae1ce04bbf"
   integrity sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==
@@ -11870,6 +11933,22 @@ viem@0.1.23:
     isomorphic-ws "^5.0.0"
     ws "^8.12.0"
 
+viem@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/viem/-/viem-1.6.0.tgz#8befa678c3ac79b9558dfd1708130b2ecb1994f4"
+  integrity sha512-ae9Twkd0q2Qlj4yYpWjb4DzYAhKY0ibEpRH8FJaTywZXNpTjFidSdBaT0CVn1BaH7O7cnX4/O47zvDUMGJD1AA==
+  dependencies:
+    "@adraffy/ens-normalize" "1.9.0"
+    "@noble/curves" "1.1.0"
+    "@noble/hashes" "1.3.0"
+    "@scure/bip32" "1.3.0"
+    "@scure/bip39" "1.2.0"
+    "@types/ws" "^8.5.4"
+    "@wagmi/chains" "1.6.0"
+    abitype "0.9.3"
+    isomorphic-ws "5.0.0"
+    ws "8.12.0"
+
 vizion@~2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/vizion/-/vizion-2.2.1.tgz#04201ea45ffd145d5b5210e385a8f35170387fb2"
@@ -12130,6 +12209,11 @@ ws@8.10.0:
   version "8.10.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.10.0.tgz#00a28c09dfb76eae4eb45c3b565f771d6951aa51"
   integrity sha512-+s49uSmZpvtAsd2h37vIPy1RBusaLawVe8of+GyEPsaJTCMpj/2v8NpeK1SHXjBlQ95lQTmQofOJnFiLoaN3yw==
+
+ws@8.12.0:
+  version "8.12.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.12.0.tgz#485074cc392689da78e1828a9ff23585e06cddd8"
+  integrity sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==
 
 ws@8.8.1:
   version "8.8.1"


### PR DESCRIPTION
# Historical data for HIIQ holders

_Logs for HIIQ contract are retrieved from the first block for the contract to 1 day apart, logs are inspected by going through each transaction and checking that the method ID used is either `create_lock` or `withdraw` after getting the unique address, a count is performed to store the total holders on a different table for the graph_

## How should this be tested?

1. query with pagination
```gql
{
  hiIQHolders(interval: WEEK) {
    amount
    day
  }
}
```

## Notes or observations

_possible intervals for the query are_
```js
enum IntervalByDays {
      DAY
      WEEK
      MONTH
      NINETY_DAYS
      YEAR
}
```

## Linked issues

closes parts of https://github.com/EveripediaNetwork/issues/issues/1656