### PR TITLE
Add cron job to get fresh logs of holders at the end of day 

### DIFF
--- a/src/App/HiIQHolders/hiIQHolder.service.ts
+++ b/src/App/HiIQHolders/hiIQHolder.service.ts
@@ -52,12 +52,23 @@ class HiIQHolderService {
     })
   }
 
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+  async checkForNewHolders() {
+    if (firstLevelNodeProcess()) {
+      await this.indexHIIQHolders()
+    }
+  }
+
   @Cron(CronExpression.EVERY_5_SECONDS, {
     name: 'storeHiIQHolderCount',
   })
   async storeHiIQHolderCount() {
+    const today = new Date()
+    const oneDayBack = new Date(today)
+    oneDayBack.setDate(oneDayBack.getDate() - 1)
+
     const job = this.schedulerRegistry.getCronJob('storeHiIQHolderCount')
-    await stopJob(this.repo, job)
+    await stopJob(this.repo, job, oneDayBack)
 
     if (firstLevelNodeProcess()) {
       await this.indexHIIQHolders()

--- a/src/App/StakedIQ/stakedIQ.utils.ts
+++ b/src/App/StakedIQ/stakedIQ.utils.ts
@@ -60,13 +60,14 @@ interface EntityWithCreated {
 export const stopJob = async <T extends EntityWithCreated>(
   repo: Repository<T>,
   job: CronJob,
+  date?: Date,
 ) => {
   const oldRecord = await leastRecordByDate(repo)
 
   if (oldRecord.length > 0 && oldRecord[0].created) {
     const oldDate = dateOnly(oldRecord[0].created)
     const presentDate = dateOnly(todayMidnightDate)
-    if (oldDate === presentDate) {
+    if (oldDate === (date || presentDate)) {
       job.stop()
     }
   }


### PR DESCRIPTION
Add cron job to get fresh logs of holders at the end of day and stop indexing old data one day back