### PR TITLE
NFT rankpage filter

### DIFF
--- a/src/App/Tag/tag.service.spec.ts
+++ b/src/App/Tag/tag.service.spec.ts
@@ -54,16 +54,27 @@ describe('TagService', () => {
   })
 
   describe('getTagById', () => {
-    it('should get a tag by ID', async () => {
+    it('should get a tag by ID and wikis using the tag', async () => {
       const args: ArgsById = {
         id: '123',
       }
 
-      jest.spyOn(service, 'findOneBy').mockResolvedValue(new Tag())
+      const createQueryBuilder: any = {
+        where: jest.fn().mockImplementation(() => createQueryBuilder),
+        getOne: () => new Tag(),
+      }
+
+      jest
+        .spyOn(service, 'createQueryBuilder')
+        .mockImplementation(() => createQueryBuilder)
 
       await service.getTagById(args)
 
-      expect(service.findOneBy).toHaveBeenCalledWith({ id: args.id })
+      expect(service.createQueryBuilder).toHaveBeenCalled()
+      expect(service.createQueryBuilder().where).toHaveBeenCalledWith(
+        'tag.id ILIKE :id',
+        { id: `%${args.id}%` },
+      )
     })
   })
 

--- a/src/App/Tag/tag.service.ts
+++ b/src/App/Tag/tag.service.ts
@@ -20,7 +20,9 @@ class TagService extends Repository<Tag> {
   }
 
   async getTagById(args: ArgsById): Promise<Tag | null> {
-    return this.findOneBy({ id: args.id.toLowerCase() })
+    return this.createQueryBuilder('tag')
+      .where('tag.id ILIKE :id', { id: `%${args.id}%` })
+      .getOne()
   }
 
   async getTagsById(args: TagIDArgs): Promise<Tag[]> {

--- a/src/App/marketCap/marketCap.service.ts
+++ b/src/App/marketCap/marketCap.service.ts
@@ -154,9 +154,13 @@ class MarketCapService {
         alias: null,
         name: element.name || '',
         image: element.image.small || '',
+        native_currency: element.native_currency || '',
+        native_currency_symbol: element.native_currency_symbol || '',
         floor_price_eth: element.floor_price.native_currency || 0,
         floor_price_usd: element.floor_price.usd || 0,
         market_cap_usd: element.market_cap.usd || 0,
+        h24_volume_usd: element.volume_24h.usd || 0,
+        h24_volume_native_currency: element.volume_24h.native_currency || 0,
         floor_price_in_usd_24h_percentage_change:
           element.floor_price_in_usd_24h_percentage_change || 0,
       }

--- a/src/App/marketCap/marketCap.service.ts
+++ b/src/App/marketCap/marketCap.service.ts
@@ -134,7 +134,7 @@ class MarketCapService {
     try {
       data = await this.httpService
         .get(
-          ` https://pro-api.coingecko.com/api/v3/nfts/markets?asset_platform_id=ethereum&order=market_cap_usd_desc&per_page=${amount}&page=${
+          ` https://pro-api.coingecko.com/api/v3/nfts/markets?order=h24_volume_usd_desc&per_page=${amount}&page=${
             page === 0 ? 1 : page
           }`,
           {

--- a/src/App/marketCap/marketcap.dto.ts
+++ b/src/App/marketCap/marketcap.dto.ts
@@ -38,6 +38,18 @@ export class NftListData extends MarketDataGenerals {
   market_cap_usd!: number
 
   @Field()
+  native_currency!: string
+
+  @Field()
+  native_currency_symbol!: string
+
+  @Field()
+  h24_volume_usd!: number
+
+  @Field()
+  h24_volume_native_currency!: number
+
+  @Field()
   floor_price_in_usd_24h_percentage_change!: number
 }
 


### PR DESCRIPTION
# NFT rankpage filter

_Removes asset platform filter to retrieve NFTs across all chains, sorts by 24h volume in USD_


## Notes or observations

_More fields have been added on the NftRankListData for more control_
```gql
{
        native_currency
        native_currency_symbol
        h24_volume_usd
  	h24_volume_native_currency
}
```

## Linked issues
 closes https://github.com/EveripediaNetwork/issues/issues/1717
