### PR TITLE
Update order for wiki per visits api

### DIFF
--- a/src/App/Activities/activity.resolver.ts
+++ b/src/App/Activities/activity.resolver.ts
@@ -6,7 +6,6 @@ import {
   ActivityByCategoryArgs,
   ByIdAndBlockArgs,
 } from './dto/activity.dto'
-import { ArgsById } from '../utils/queryHelpers'
 import User from '../../Database/Entities/user.entity'
 import Wiki from '../../Database/Entities/wiki.entity'
 import SelectedFields from '../utils/getFields'
@@ -19,6 +18,7 @@ import {
   Count,
   DateArgs,
 } from '../Wiki/wikiStats.dto'
+import { ArgsById } from '../general.args'
 
 @Resolver(() => Activity)
 class ActivityResolver {

--- a/src/App/Activities/dto/activity.dto.ts
+++ b/src/App/Activities/dto/activity.dto.ts
@@ -2,7 +2,7 @@ import { ArgsType, Field, Int } from '@nestjs/graphql'
 import { Validate } from 'class-validator'
 import PaginationArgs from '../../pagination.args'
 import ValidStringParams from '../../utils/customValidator'
-import { ActivityType } from '../../utils/queryHelpers'
+import { ActivityType } from '../../general.args'
 
 @ArgsType()
 export class ActivityArgs extends PaginationArgs {

--- a/src/App/Category/category.resolver.ts
+++ b/src/App/Category/category.resolver.ts
@@ -4,9 +4,9 @@ import Category from '../../Database/Entities/category.entity'
 import PaginationArgs from '../pagination.args'
 import Wiki from '../../Database/Entities/wiki.entity'
 import { ICategory } from '../../Database/Entities/types/ICategory'
-import { ArgsById } from '../utils/queryHelpers'
 import CategoryService from './category.service'
 import { TitleArgs } from '../Wiki/wiki.dto'
+import { ArgsById } from '../general.args'
 
 // TODO: test Categories resolver
 @Resolver(() => Category)

--- a/src/App/Category/category.service.ts
+++ b/src/App/Category/category.service.ts
@@ -4,7 +4,7 @@ import { DataSource, MoreThan, Repository } from 'typeorm'
 import Category from '../../Database/Entities/category.entity'
 import PaginationArgs from '../pagination.args'
 import { TitleArgs } from '../Wiki/wiki.dto'
-import { ArgsById } from '../utils/queryHelpers'
+import { ArgsById } from '../general.args'
 
 @Injectable()
 class CategoryService extends Repository<Category> {

--- a/src/App/HiIQHolders/hiIQHolders.dto.ts
+++ b/src/App/HiIQHolders/hiIQHolders.dto.ts
@@ -1,7 +1,7 @@
 import { ArgsType, Field, Int } from '@nestjs/graphql'
 import { Min, Max } from 'class-validator'
-import { IntervalByDays } from '../utils/queryHelpers'
 import PaginationArgs from '../pagination.args'
+import { IntervalByDays } from '../general.args'
 
 @ArgsType()
 export default class HiIQHolderArgs extends PaginationArgs {

--- a/src/App/IQHolders/IQHolders.dto.ts
+++ b/src/App/IQHolders/IQHolders.dto.ts
@@ -1,8 +1,8 @@
 import { ArgsType, Field, Int } from '@nestjs/graphql'
 import { Min, Max } from 'class-validator'
 import { Injectable } from '@nestjs/common'
-import { IntervalByDays } from '../utils/queryHelpers'
 import PaginationArgs from '../pagination.args'
+import { IntervalByDays } from '../general.args'
 
 @ArgsType()
 export default class IQHolderArgs extends PaginationArgs {

--- a/src/App/Tag/tag.resolver.ts
+++ b/src/App/Tag/tag.resolver.ts
@@ -4,10 +4,10 @@ import Tag from '../../Database/Entities/tag.entity'
 import PaginationArgs from '../pagination.args'
 import Wiki from '../../Database/Entities/wiki.entity'
 import { ITag } from '../../Database/Entities/types/ITag'
-import { ArgsById } from '../utils/queryHelpers'
 import TagService from './tag.service'
 import TagIDArgs from './tag.dto'
 import { DateArgs } from '../Wiki/wikiStats.dto'
+import { ArgsById } from '../general.args'
 
 @Resolver(() => Tag)
 class TagResolver {

--- a/src/App/User/user.resolver.ts
+++ b/src/App/User/user.resolver.ts
@@ -26,8 +26,8 @@ import IsActiveGuard from '../utils/isActive.guard'
 import AdminLogsInterceptor from '../utils/adminLogs.interceptor'
 import UserService from './user.service'
 import { UsersByEditArgs, UsersByIdArgs, UserStateArgs } from './user.dto'
-import { ArgsById } from '../utils/queryHelpers'
 import SelectedFields from '../utils/getFields'
+import { ArgsById } from '../general.args'
 
 @UseInterceptors(AdminLogsInterceptor)
 @Resolver(() => User)

--- a/src/App/Wiki/wiki.dto.ts
+++ b/src/App/Wiki/wiki.dto.ts
@@ -2,7 +2,7 @@
 import { ArgsType, Field, Int, ObjectType } from '@nestjs/graphql'
 import { MinLength, Validate } from 'class-validator'
 import ValidStringParams from '../utils/customValidator'
-import { Direction, OrderBy } from '../utils/queryHelpers'
+import { Direction, OrderBy } from '../general.args'
 import PaginationArgs from '../pagination.args'
 
 @ArgsType()
@@ -50,24 +50,6 @@ export class ByIdArgs {
 export class PromoteWikiArgs extends ByIdArgs {
   @Field(() => Int)
   level = 0
-}
-
-@ArgsType()
-export class PageViewArgs {
-  @Field(() => Int)
-  amount!: number
-
-  @Field(() => String, { description: 'Format <YYYY/MM/DD>' })
-  @Validate(ValidStringParams)
-  startDay!: string
-
-  @Field(() => String, { description: 'Format <YYYY/MM/DD>' })
-  @Validate(ValidStringParams)
-  endDay!: string
-
-  @Field(() => String, { nullable: true })
-  @Validate(ValidStringParams)
-  category?: string
 }
 
 @ObjectType()

--- a/src/App/Wiki/wiki.service.ts
+++ b/src/App/Wiki/wiki.service.ts
@@ -4,9 +4,7 @@ import { DataSource, MoreThan, Repository } from 'typeorm'
 import { Cache } from 'cache-manager'
 import { HttpService } from '@nestjs/axios'
 import Wiki from '../../Database/Entities/wiki.entity'
-import {
-  orderWikis,
-} from '../utils/queryHelpers'
+import { orderWikis } from '../utils/queryHelpers'
 import { ValidSlug, Valid, Slug } from '../utils/validSlug'
 import {
   ByIdArgs,
@@ -260,7 +258,9 @@ class WikiService {
           : []
 
       for (const promotedWiki of promotedWikis) {
-        await (await this.repository())
+        await (
+          await this.repository()
+        )
           .createQueryBuilder()
           .update(Wiki)
           .set({ promoted: 0 })
@@ -268,7 +268,9 @@ class WikiService {
           .execute()
       }
 
-      await (await this.repository())
+      await (
+        await this.repository()
+      )
         .createQueryBuilder()
         .update(Wiki)
         .set({ promoted: args.level })
@@ -281,7 +283,9 @@ class WikiService {
 
   async hideWiki(args: ByIdArgs): Promise<Wiki | null> {
     const wiki = (await this.repository()).findOneBy({ id: args.id })
-    await (await this.repository())
+    await (
+      await this.repository()
+    )
       .createQueryBuilder()
       .update(Wiki)
       .set({ hidden: true, promoted: 0 })
@@ -292,7 +296,9 @@ class WikiService {
 
   async unhideWiki(args: ByIdArgs): Promise<Wiki | null> {
     const wiki = (await this.repository()).findOneBy({ id: args.id })
-    await (await this.repository())
+    await (
+      await this.repository()
+    )
       .createQueryBuilder()
       .update(Wiki)
       .set({ hidden: false })
@@ -318,7 +324,9 @@ class WikiService {
   async getCategoryTotal(args: CategoryArgs): Promise<Count | undefined> {
     const count: any | undefined = await this.cacheManager.get(args.category)
     if (count) return count
-    const response = await (await this.repository())
+    const response = await (
+      await this.repository()
+    )
       .createQueryBuilder('wiki')
       .select('Count(wiki.id)', 'amount')
       .innerJoin('wiki_categories_category', 'wc', 'wc."wikiId" = wiki.id')

--- a/src/App/Wiki/wiki.service.ts
+++ b/src/App/Wiki/wiki.service.ts
@@ -132,7 +132,7 @@ class WikiService {
       })
       .limit(args.amount)
       .groupBy('wiki.id')
-      .orderBy('Sum(p.visits)', 'DESC')
+      .orderBy('views', 'DESC')
 
     if (args.category) {
       qb.innerJoin('wiki.categories', 'category', 'category.id = :categoryId', {

--- a/src/App/general.args.ts
+++ b/src/App/general.args.ts
@@ -1,0 +1,42 @@
+import { ArgsType, Field, registerEnumType } from '@nestjs/graphql'
+import { Validate } from 'class-validator'
+import ValidStringParams from './utils/customValidator'
+
+export enum OrderBy {
+  ID = 'id',
+  VIEWS = 'views',
+  BLOCK = 'block',
+  CREATED = 'created',
+  UPDATED = 'updated',
+  DAY = 'day',
+}
+
+export enum ActivityType {
+  CREATED = 0,
+  UPDATED = 1,
+}
+
+export enum Direction {
+  ASC = 'ASC',
+  DESC = 'DESC',
+}
+
+export enum IntervalByDays {
+  DAY = 1,
+  WEEK = 7,
+  MONTH = 30,
+  NINETY_DAYS = 90,
+  YEAR = 365,
+}
+
+@ArgsType()
+export class ArgsById {
+  @Field(() => String)
+  @Validate(ValidStringParams)
+  id!: string
+}
+
+registerEnumType(OrderBy, { name: 'OrderBy' })
+registerEnumType(Direction, { name: 'Direction' })
+registerEnumType(ActivityType, { name: 'ActivityType' })
+registerEnumType(IntervalByDays, { name: 'IntervalByDays' })

--- a/src/App/pageViews/pageViews.resolver.ts
+++ b/src/App/pageViews/pageViews.resolver.ts
@@ -1,10 +1,10 @@
 import { Args, Context, Mutation, Query, Resolver } from '@nestjs/graphql'
 import { UseInterceptors, UseGuards } from '@nestjs/common'
 import PageViewsService from './pageViews.service'
-import { ArgsById } from '../utils/queryHelpers'
 import AuthGuard from '../utils/admin.guard'
 import AdminLogsInterceptor from '../utils/adminLogs.interceptor'
 import { WikiViewArgs, WikiViews } from './pageviews.dto'
+import { ArgsById } from '../general.args'
 
 @UseInterceptors(AdminLogsInterceptor)
 @Resolver(() => Number)

--- a/src/App/pageViews/pageviews.dto.ts
+++ b/src/App/pageViews/pageviews.dto.ts
@@ -54,5 +54,4 @@ export class PageViewArgs extends VistArgs {
   category?: string
 }
 
-
 export default WikiViews

--- a/src/App/pageViews/pageviews.dto.ts
+++ b/src/App/pageViews/pageviews.dto.ts
@@ -5,9 +5,10 @@ import {
   Int,
   ObjectType,
 } from '@nestjs/graphql'
-import { Min, Max } from 'class-validator'
+import { Min, Max, Validate } from 'class-validator'
 import { OrderArgs } from '../pagination.args'
-import { OrderBy } from '../utils/queryHelpers'
+import ValidStringParams from '../utils/customValidator'
+import { OrderBy, IntervalByDays } from '../general.args'
 
 @ObjectType()
 export class WikiViews {
@@ -28,5 +29,30 @@ export class WikiViewArgs extends OrderArgs {
   @Field(() => OrderBy)
   order = OrderBy.DAY
 }
+
+@ArgsType()
+export class VistArgs {
+  @Field(() => IntervalByDays, { nullable: true })
+  interval = IntervalByDays.WEEK
+}
+
+@ArgsType()
+export class PageViewArgs extends VistArgs {
+  @Field(() => Int)
+  amount!: number
+
+  @Field(() => String, { description: 'Format <YYYY/MM/DD>', nullable: true })
+  @Validate(ValidStringParams)
+  startDay?: string
+
+  @Field(() => String, { description: 'Format <YYYY/MM/DD>', nullable: true })
+  @Validate(ValidStringParams)
+  endDay?: string
+
+  @Field(() => String, { nullable: true })
+  @Validate(ValidStringParams)
+  category?: string
+}
+
 
 export default WikiViews

--- a/src/App/pagination.args.spec.ts
+++ b/src/App/pagination.args.spec.ts
@@ -1,6 +1,6 @@
 import { validateSync } from 'class-validator'
 import PaginationArgs, { OrderArgs } from './pagination.args'
-import { Direction, OrderBy } from './utils/queryHelpers'
+import { Direction, OrderBy } from './general.args'
 
 describe('PaginationArgs', () => {
   const args = new PaginationArgs()

--- a/src/App/pagination.args.ts
+++ b/src/App/pagination.args.ts
@@ -1,6 +1,6 @@
 import { ArgsType, Field, Int } from '@nestjs/graphql'
 import { Min, Max } from 'class-validator'
-import { Direction, OrderBy } from './utils/queryHelpers'
+import { Direction, OrderBy } from './general.args'
 
 @ArgsType()
 class PaginationArgs {

--- a/src/App/utils/queryHelpers.ts
+++ b/src/App/utils/queryHelpers.ts
@@ -2,7 +2,6 @@ import { Repository } from 'typeorm'
 import Activity from '../../Database/Entities/activity.entity'
 import { OrderBy, Direction } from '../general.args'
 
-
 export const orderWikis = (order: OrderBy, direction: Direction) => {
   let sortValue = {}
   switch (order) {

--- a/src/App/utils/queryHelpers.ts
+++ b/src/App/utils/queryHelpers.ts
@@ -1,47 +1,7 @@
-import { ArgsType, Field, registerEnumType } from '@nestjs/graphql'
 import { Repository } from 'typeorm'
-import { Validate } from 'class-validator'
 import Activity from '../../Database/Entities/activity.entity'
-import ValidStringParams from './customValidator'
+import { OrderBy, Direction } from '../general.args'
 
-export enum OrderBy {
-  ID = 'id',
-  VIEWS = 'views',
-  BLOCK = 'block',
-  CREATED = 'created',
-  UPDATED = 'updated',
-  DAY = 'day',
-}
-
-export enum ActivityType {
-  CREATED = 0,
-  UPDATED = 1,
-}
-
-export enum Direction {
-  ASC = 'ASC',
-  DESC = 'DESC',
-}
-
-export enum IntervalByDays {
-  DAY = 1,
-  WEEK = 7,
-  MONTH = 30,
-  NINETY_DAYS = 90,
-  YEAR = 365,
-}
-
-@ArgsType()
-export class ArgsById {
-  @Field(() => String)
-  @Validate(ValidStringParams)
-  id!: string
-}
-
-registerEnumType(OrderBy, { name: 'OrderBy' })
-registerEnumType(Direction, { name: 'Direction' })
-registerEnumType(ActivityType, { name: 'ActivityType' })
-registerEnumType(IntervalByDays, { name: 'IntervalByDays' })
 
 export const orderWikis = (order: OrderBy, direction: Direction) => {
   let sortValue = {}

--- a/src/Database/Entities/pageviewsPerPage.entity.ts
+++ b/src/Database/Entities/pageviewsPerPage.entity.ts
@@ -1,7 +1,7 @@
 import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm'
 import { Field, GraphQLISODateTime, ID, ObjectType } from '@nestjs/graphql'
 
-@ObjectType({ description: 'User subscriptions' })
+@ObjectType()
 @Entity()
 class PageviewsPerDay {
   @Field(() => ID)

--- a/src/Database/Entities/wiki.entity.ts
+++ b/src/Database/Entities/wiki.entity.ts
@@ -76,6 +76,12 @@ class Wiki {
   @Column('integer', { default: 0 })
   views!: number
 
+  @Field(() => Int, {
+    nullable: true,
+    defaultValue: 0,
+  })
+  visits?: number
+
   @Field(() => Int)
   @Column('smallint', { default: 0 })
   promoted = 0


### PR DESCRIPTION
## How to test?

```gql
   {
         wikisPerVisits(amount: 20, interval: WEEK){
            id
            title
            views
            visits(interval: WEEK)
	    categories {
		   id
	     }
            tags {
                 id
            }
       }
   }
```
_startDay and endDay params are now optional, interval has been added to support a controlled dataset for every interval. It will default to a weekly interval if the startDay and endDay are not passed, and for data consistency only call `visits(interval: WEEK)` field and pass the interval option when using `interval: WEEK` on wikisPerVisists as well_
cc @Aliiiu  @Softdev1 
 closes part of https://github.com/EveripediaNetwork/issues/issues/1801
