### PR TITLE
Disable old data cron

### DIFF
--- a/src/App/HiIQHolders/hiIQHolder.service.ts
+++ b/src/App/HiIQHolders/hiIQHolder.service.ts
@@ -67,6 +67,7 @@ class HiIQHolderService {
 
   @Cron(CronExpression.EVERY_5_SECONDS, {
     name: 'storeHiIQHolderCount',
+    disabled: true
   })
   async storeHiIQHolderCount() {
     const today = new Date()

--- a/src/App/IQHolders/IQHolder.service.ts
+++ b/src/App/IQHolders/IQHolder.service.ts
@@ -64,6 +64,7 @@ class IQHolderService {
 
   @Cron(CronExpression.EVERY_5_SECONDS, {
     name: cronIndexerId,
+    disabled: true
   })
   async storeIQHolderCount() {
     const tempStop: boolean | undefined = await this.cacheManager.get(

--- a/src/App/StakedIQ/stakedIQ.service.ts
+++ b/src/App/StakedIQ/stakedIQ.service.ts
@@ -45,6 +45,7 @@ class StakedIQService {
 
   @Cron(CronExpression.EVERY_5_SECONDS, {
     name: 'IndexOldStakedIQ',
+    disabled: true
   })
   async indexOldStakedBalance(): Promise<void> {
     const job = this.schedulerRegistry.getCronJob('IndexOldStakedIQ')

--- a/src/sentry/sentry.module.ts
+++ b/src/sentry/sentry.module.ts
@@ -2,7 +2,7 @@ import { Module } from '@nestjs/common'
 import { ConfigModule, ConfigService } from '@nestjs/config'
 import { SentryModule } from '@ntegral/nestjs-sentry'
 
-const ignoredEndpoints = ['/brainpass/nft-events', 'indexer']
+const ignoredEndpoints = ['/brainpass/nft-events', '/indexer']
 
 @Module({
   imports: [


### PR DESCRIPTION
_Disables con job for indexing old data for iq graphs and properly ignores indexer events api for sentry _


 closes https://github.com/EveripediaNetwork/issues/issues/1887
