### PR TITLE
Founders rankpage api

### DIFF
--- a/src/App/Wiki/wiki.resolver.ts
+++ b/src/App/Wiki/wiki.resolver.ts
@@ -163,6 +163,13 @@ class WikiResolver {
       .getRawOne()
     return visits
   }
+
+  @ResolveField(() => [Wiki], { nullable: true })
+  async founderWikis(@Parent() wiki: IWiki) {
+    return this.wikiService.getFounderWikis(
+      wiki.linkedWikis.founders as string[],
+    )
+  }
 }
 
 export default WikiResolver

--- a/src/App/Wiki/wiki.resolver.ts
+++ b/src/App/Wiki/wiki.resolver.ts
@@ -31,6 +31,7 @@ import { Count, DateArgs } from './wikiStats.dto'
 import { IWiki } from '../../Database/Entities/types/IWiki'
 import PageviewsPerDay from '../../Database/Entities/pageviewsPerPage.entity'
 import { PageViewArgs, VistArgs } from '../pageViews/pageviews.dto'
+import { updateDates } from '../utils/queryHelpers'
 
 @UseInterceptors(AdminLogsInterceptor)
 @Resolver(() => Wiki)
@@ -152,7 +153,7 @@ class WikiResolver {
 
   @ResolveField()
   async visits(@Parent() wiki: IWiki, @Args() args: VistArgs) {
-    const { start, end } = await this.wikiService.updateDates(args)
+    const { start, end } = await updateDates(args)
     const { visits } = await this.dataSource
       .getRepository(PageviewsPerDay)
       .createQueryBuilder('p')

--- a/src/App/Wiki/wiki.service.ts
+++ b/src/App/Wiki/wiki.service.ts
@@ -258,7 +258,9 @@ class WikiService {
           : []
 
       for (const promotedWiki of promotedWikis) {
-        await (await this.repository())
+        await (
+          await this.repository()
+        )
           .createQueryBuilder()
           .update(Wiki)
           .set({ promoted: 0 })
@@ -266,7 +268,9 @@ class WikiService {
           .execute()
       }
 
-      await (await this.repository())
+      await (
+        await this.repository()
+      )
         .createQueryBuilder()
         .update(Wiki)
         .set({ promoted: args.level })
@@ -279,7 +283,9 @@ class WikiService {
 
   async hideWiki(args: ByIdArgs): Promise<Wiki | null> {
     const wiki = (await this.repository()).findOneBy({ id: args.id })
-    await (await this.repository())
+    await (
+      await this.repository()
+    )
       .createQueryBuilder()
       .update(Wiki)
       .set({ hidden: true, promoted: 0 })
@@ -290,7 +296,9 @@ class WikiService {
 
   async unhideWiki(args: ByIdArgs): Promise<Wiki | null> {
     const wiki = (await this.repository()).findOneBy({ id: args.id })
-    await (await this.repository())
+    await (
+      await this.repository()
+    )
       .createQueryBuilder()
       .update(Wiki)
       .set({ hidden: false })
@@ -316,7 +324,9 @@ class WikiService {
   async getCategoryTotal(args: CategoryArgs): Promise<Count | undefined> {
     const count: any | undefined = await this.cacheManager.get(args.category)
     if (count) return count
-    const response = await (await this.repository())
+    const response = await (
+      await this.repository()
+    )
       .createQueryBuilder('wiki')
       .select('Count(wiki.id)', 'amount')
       .innerJoin('wiki_categories_category', 'wc', 'wc."wikiId" = wiki.id')
@@ -340,7 +350,7 @@ class WikiService {
         foundersWiki.push(f)
       }
     }
-    return foundersWiki.filter(item => item !== null)
+    return foundersWiki.filter((item) => item !== null)
   }
 }
 

--- a/src/App/Wiki/wiki.service.ts
+++ b/src/App/Wiki/wiki.service.ts
@@ -4,7 +4,7 @@ import { DataSource, MoreThan, Repository } from 'typeorm'
 import { Cache } from 'cache-manager'
 import { HttpService } from '@nestjs/axios'
 import Wiki from '../../Database/Entities/wiki.entity'
-import { orderWikis } from '../utils/queryHelpers'
+import { orderWikis, updateDates } from '../utils/queryHelpers'
 import { ValidSlug, Valid, Slug } from '../utils/validSlug'
 import {
   ByIdArgs,
@@ -17,8 +17,8 @@ import {
 import { DateArgs, Count } from './wikiStats.dto'
 import { ActionTypes } from '../utils/utilTypes'
 import WebhookHandler from '../utils/discordWebhookHandler'
-import { OrderBy, Direction, IntervalByDays } from '../general.args'
-import { VistArgs, PageViewArgs } from '../pageViews/pageviews.dto'
+import { OrderBy, Direction } from '../general.args'
+import { PageViewArgs } from '../pageViews/pageviews.dto'
 
 @Injectable()
 class WikiService {
@@ -119,33 +119,8 @@ class WikiService {
       .getMany()
   }
 
-  async updateDates(args: VistArgs) {
-    const { interval } = args
-    let start
-    let end
-
-    if (interval) {
-      const range = IntervalByDays[interval]
-      const oneDay = 86400000
-      const intervalMap: { [key: string]: number } = {
-        DAY: oneDay,
-        WEEK: 7 * oneDay,
-        MONTH: 30 * oneDay,
-        NINETY_DAYS: 90 * oneDay,
-        YEAR: 365 * oneDay,
-      }
-
-      const currentDate = new Date()
-      const endDate = new Date(currentDate.getTime() - intervalMap[range])
-
-      start = endDate.toISOString().slice(0, 10).split('-').join('/')
-      end = currentDate.toISOString().slice(0, 10).split('-').join('/')
-    }
-    return { start, end }
-  }
-
   async getWikisPerVisits(args: PageViewArgs): Promise<Wiki[] | []> {
-    const { start, end } = await this.updateDates(args)
+    const { start, end } = await updateDates(args)
     const qb = (await this.repository())
       .createQueryBuilder('wiki')
       .innerJoin('pageviews_per_day', 'p', 'p."wikiId" = wiki.id')

--- a/src/App/Wiki/wiki.service.ts
+++ b/src/App/Wiki/wiki.service.ts
@@ -258,9 +258,7 @@ class WikiService {
           : []
 
       for (const promotedWiki of promotedWikis) {
-        await (
-          await this.repository()
-        )
+        await (await this.repository())
           .createQueryBuilder()
           .update(Wiki)
           .set({ promoted: 0 })
@@ -268,9 +266,7 @@ class WikiService {
           .execute()
       }
 
-      await (
-        await this.repository()
-      )
+      await (await this.repository())
         .createQueryBuilder()
         .update(Wiki)
         .set({ promoted: args.level })
@@ -283,9 +279,7 @@ class WikiService {
 
   async hideWiki(args: ByIdArgs): Promise<Wiki | null> {
     const wiki = (await this.repository()).findOneBy({ id: args.id })
-    await (
-      await this.repository()
-    )
+    await (await this.repository())
       .createQueryBuilder()
       .update(Wiki)
       .set({ hidden: true, promoted: 0 })
@@ -296,9 +290,7 @@ class WikiService {
 
   async unhideWiki(args: ByIdArgs): Promise<Wiki | null> {
     const wiki = (await this.repository()).findOneBy({ id: args.id })
-    await (
-      await this.repository()
-    )
+    await (await this.repository())
       .createQueryBuilder()
       .update(Wiki)
       .set({ hidden: false })
@@ -324,9 +316,7 @@ class WikiService {
   async getCategoryTotal(args: CategoryArgs): Promise<Count | undefined> {
     const count: any | undefined = await this.cacheManager.get(args.category)
     if (count) return count
-    const response = await (
-      await this.repository()
-    )
+    const response = await (await this.repository())
       .createQueryBuilder('wiki')
       .select('Count(wiki.id)', 'amount')
       .innerJoin('wiki_categories_category', 'wc', 'wc."wikiId" = wiki.id')
@@ -340,6 +330,17 @@ class WikiService {
       .getRawOne()
     await this.cacheManager.set(args.category, response, { ttl: 3600 })
     return response
+  }
+
+  async getFounderWikis(founders: string[]): Promise<(Wiki | null)[]> {
+    const foundersWiki: (Wiki | null)[] = []
+    if (founders && founders.length > 0) {
+      for (const founder of founders) {
+        const f = await this.findWiki({ id: founder } as ByIdArgs)
+        foundersWiki.push(f)
+      }
+    }
+    return foundersWiki.filter(item => item !== null)
   }
 }
 

--- a/src/App/marketCap/marketCap.service.ts
+++ b/src/App/marketCap/marketCap.service.ts
@@ -5,14 +5,14 @@ import { HttpService } from '@nestjs/axios'
 import { CACHE_MANAGER, Inject, Injectable } from '@nestjs/common'
 import { Cache } from 'cache-manager'
 import { ConfigService } from '@nestjs/config'
-import Wiki from '../../Database/Entities/wiki.entity'
-import { cryptocurrencyIds, nftIds } from './marketcapIds'
 import {
   MarketCapInputs,
   NftRankListData,
   RankType,
   TokenRankListData,
 } from './marketcap.dto'
+import Wiki from '../../Database/Entities/wiki.entity'
+import { cryptocurrencyIds, nftIds } from './marketcapIds'
 import Tag from '../../Database/Entities/tag.entity'
 import WikiService from '../Wiki/wiki.service'
 
@@ -93,26 +93,9 @@ class MarketCapService {
   }
 
   private async cryptoMarketData(args: MarketCapInputs) {
-    const { limit, offset, founders, category } = args
+    const { founders, category } = args
     const categoryParam = category ? `category=${category}&` : ''
-    let data
-
-    try {
-      data = await this.httpService
-        .get(
-          ` https://pro-api.coingecko.com/api/v3/coins/markets?vs_currency=usd&${categoryParam}order=market_cap_desc&per_page=${limit}&page=${
-            offset === 0 ? 1 : offset
-          }&sparkline=false`,
-          {
-            headers: {
-              'x-cg-pro-api-key': this.apiKey(),
-            },
-          },
-        )
-        .toPromise()
-    } catch (err: any) {
-      console.error(err.message)
-    }
+    const data = await this.cgMarketDataApiCall(args, categoryParam)
 
     const result = data?.data.map(async (element: any) => {
       const wiki = await this.findWiki(
@@ -165,24 +148,8 @@ class MarketCapService {
   }
 
   private async nftMarketData(args: MarketCapInputs) {
-    const { limit, offset, founders } = args
-    let data
-    try {
-      data = await this.httpService
-        .get(
-          ` https://pro-api.coingecko.com/api/v3/nfts/markets?order=h24_volume_usd_desc&per_page=${limit}&page=${
-            offset === 0 ? 1 : offset
-          }`,
-          {
-            headers: {
-              'x-cg-pro-api-key': this.apiKey(),
-            },
-          },
-        )
-        .toPromise()
-    } catch (err: any) {
-      console.error(err.message)
-    }
+    const { founders } = args
+    const data = await this.cgMarketDataApiCall(args)
 
     const result = data?.data.map(async (element: any) => {
       const wiki = await this.findWiki(element.id, nftIds, 'nfts')
@@ -232,12 +199,39 @@ class MarketCapService {
     return result
   }
 
+  async cgMarketDataApiCall(
+    args: MarketCapInputs,
+    categoryParam?: string,
+  ): Promise<Record<any, any> | undefined> {
+    const { limit, offset, kind } = args
+    let data
+    const baseUrl = `https://pro-api.coingecko.com/api/v3/`
+    const paginate = `&per_page=${limit}&page=${offset === 0 ? 1 : offset}`
+    const url =
+      kind === RankType.TOKEN
+        ? `${baseUrl}coins/markets?vs_currency=usd&${categoryParam}order=market_cap_des${paginate}`
+        : `${baseUrl}nfts/markets?order=h24_volume_usd_desc${paginate}`
+
+    try {
+      data = await this.httpService
+        .get(url, {
+          headers: {
+            'x-cg-pro-api-key': this.apiKey(),
+          },
+        })
+        .toPromise()
+    } catch (err: any) {
+      console.error(err.message)
+    }
+    return data
+  }
+
   async ranks(
     args: MarketCapInputs,
   ): Promise<TokenRankListData | NftRankListData> {
-    const key = args.category
-      ? `finalResult/${args.kind}/${args.limit}/${args.offset}/${args.founders}-${args.category}`
-      : `finalResult/${args.kind}/${args.limit}/${args.offset}/${args.founders}`
+    const key = `finalResult/${args.kind}/${args.limit}/${args.offset}/${
+      args.founders
+    }${args.category ? `/${args.category}` : ''}`
 
     const finalCachedResult: any | undefined = await this.cacheManager.get(key)
 

--- a/src/App/marketCap/marketCap.service.ts
+++ b/src/App/marketCap/marketCap.service.ts
@@ -205,7 +205,7 @@ class MarketCapService {
   ): Promise<Record<any, any> | undefined> {
     const { limit, offset, kind } = args
     let data
-    const baseUrl = `https://pro-api.coingecko.com/api/v3/`
+    const baseUrl = 'https://pro-api.coingecko.com/api/v3/'
     const paginate = `&per_page=${limit}&page=${offset === 0 ? 1 : offset}`
     const url =
       kind === RankType.TOKEN

--- a/src/App/marketCap/marketcap.dto.ts
+++ b/src/App/marketCap/marketcap.dto.ts
@@ -105,6 +105,7 @@ export enum RankType {
 export enum TokenCategory {
   AI = 'artificial-intelligence',
   STABLE_COINS = 'stablecoins',
+  FOUNDERS = 'founders',
 }
 
 registerEnumType(RankType, {
@@ -123,4 +124,7 @@ export class MarketCapInputs extends PaginationArgs {
   @Field(() => TokenCategory, { nullable: true })
   @Validate(ValidStringParams)
   category?: TokenCategory
+
+  @Field(() => Boolean, {defaultValue: false})
+  founders!: boolean
 }

--- a/src/App/marketCap/marketcap.dto.ts
+++ b/src/App/marketCap/marketcap.dto.ts
@@ -119,7 +119,7 @@ registerEnumType(TokenCategory, {
 export class MarketCapInputs extends PaginationArgs {
   @Field(() => RankType, { defaultValue: RankType.TOKEN })
   @Validate(ValidStringParams)
-  kind?: RankType
+  kind!: RankType
 
   @Field(() => TokenCategory, { nullable: true })
   @Validate(ValidStringParams)

--- a/src/App/utils/queryHelpers.ts
+++ b/src/App/utils/queryHelpers.ts
@@ -1,6 +1,7 @@
 import { Repository } from 'typeorm'
 import Activity from '../../Database/Entities/activity.entity'
-import { OrderBy, Direction } from '../general.args'
+import { OrderBy, Direction, IntervalByDays } from '../general.args'
+import { VistArgs } from '../pageViews/pageviews.dto'
 
 export const orderWikis = (order: OrderBy, direction: Direction) => {
   let sortValue = {}
@@ -76,3 +77,28 @@ export const queryWikisEdited = async (
     `,
     [id, limit, offset],
   )
+
+export const updateDates = async (args: VistArgs) => {
+  const { interval } = args
+  let start
+  let end
+
+  if (interval) {
+    const range = IntervalByDays[interval]
+    const oneDay = 86400000
+    const intervalMap: { [key: string]: number } = {
+      DAY: oneDay,
+      WEEK: 7 * oneDay,
+      MONTH: 30 * oneDay,
+      NINETY_DAYS: 90 * oneDay,
+      YEAR: 365 * oneDay,
+    }
+
+    const currentDate = new Date()
+    const endDate = new Date(currentDate.getTime() - intervalMap[range])
+
+    start = endDate.toISOString().slice(0, 10).split('-').join('/')
+    end = currentDate.toISOString().slice(0, 10).split('-').join('/')
+  }
+  return { start, end }
+}

--- a/src/Database/Entities/types/IWiki.ts
+++ b/src/Database/Entities/types/IWiki.ts
@@ -2,10 +2,12 @@
 // right now only used ones are added
 
 import { ArgsType, Field } from '@nestjs/graphql'
+import LinkedWikis from './ILinkedWikis'
 
 export interface IWiki {
   id: string
   title: string
+  linkedWikis: LinkedWikis
 }
 
 @ArgsType()

--- a/src/Database/Entities/wiki.entity.ts
+++ b/src/Database/Entities/wiki.entity.ts
@@ -82,6 +82,9 @@ class Wiki {
   })
   visits?: number
 
+  @Field(() => [Wiki], { nullable: true })
+  founderWikis?: Wiki[]
+
   @Field(() => Int)
   @Column('smallint', { default: 0 })
   promoted = 0


### PR DESCRIPTION
_Some wiki information is not present on the rankpage api, the founder's wiki. This update adds an extra n+1 query to get wikis of founders, the default state for founders is `false` except specified `true` in order to reduce excess requests_

## How to test?
query snippet
```gql
{
  rankList(kind: TOKEN limit: 30, offset:0, founders: true){
      ... on TokenRankListData {
        id
        title
        ipfs
        created
        linkedWikis {
          founders
          blockchains
        }
        founderWikis {
      	  title
      	  images {
            id
      	  }
    	}
```
## Notes
_`founderWikis` field is a [Wiki] type_
## Linked issues

 closes https://github.com/EveripediaNetwork/issues/issues/1928
