### PR TITLE
securityTester file update and test file update

### DIFF
--- a/src/App/utils/securityTester.ts
+++ b/src/App/utils/securityTester.ts
@@ -87,8 +87,9 @@ export default class SecurityTestingService {
     const alertObfuscation =
       /\b(alert|a=alert,a|\[1\]\.find\(alert\)|top\["al"\s*\+\s*"ert"\]\(1\)|top\/al\/.source\s*\+\s*\/ert\/.source\(1\)|al\\u0065rt\(1\)|top\['al\\145rt'\]\(1\)|top\['al\\x65rt'\]\(1\)|top\[8680439..toString\(30\)\]\(1\)|alert\?\(\)|`${alert``}`)\b/
 
-    const evalObfuscation =
-      /(^|\W)(alert|eval|prompt|confirm)((\s*?)?(\?)?\s*?\(|\s+)(.*?)(\s*?)?(\)|;|$|\W)/gi
+      const evalObfuscation =
+  /(^|\W)(alert|eval|prompt|confirm(?!\s+scheduling)((\s*?)?(\?)?\s*?\(|\s+)(.*?)(\s*?)?(\)|;|$|\W))/gi;
+    
     const jsURISchemeRegex =
       /(?=.*javascript:|.*data:)(?!(?:['"]?(?:on\w+|style)\s*=|\w+\s*=)\s*(?:\(|&#[xX]28;|%28|['"]?\+?\d))/i
 

--- a/src/App/utils/securityTester.ts
+++ b/src/App/utils/securityTester.ts
@@ -87,9 +87,9 @@ export default class SecurityTestingService {
     const alertObfuscation =
       /\b(alert|a=alert,a|\[1\]\.find\(alert\)|top\["al"\s*\+\s*"ert"\]\(1\)|top\/al\/.source\s*\+\s*\/ert\/.source\(1\)|al\\u0065rt\(1\)|top\['al\\145rt'\]\(1\)|top\['al\\x65rt'\]\(1\)|top\[8680439..toString\(30\)\]\(1\)|alert\?\(\)|`${alert``}`)\b/
 
-      const evalObfuscation =
-  /(^|\W)(alert|eval|prompt|confirm(?!\s+scheduling)((\s*?)?(\?)?\s*?\(|\s+)(.*?)(\s*?)?(\)|;|$|\W))/gi;
-    
+    const evalObfuscation =
+      /(^|\W)(alert|eval|prompt|confirm(?!\s+scheduling)((\s*?)?(\?)?\s*?\(|\s+)(.*?)(\s*?)?(\)|;|$|\W))/gi
+
     const jsURISchemeRegex =
       /(?=.*javascript:|.*data:)(?!(?:['"]?(?:on\w+|style)\s*=|\w+\s*=)\s*(?:\(|&#[xX]28;|%28|['"]?\+?\d))/i
 

--- a/src/App/utils/utils-spec/securityTester.spec.ts
+++ b/src/App/utils/utils-spec/securityTester.spec.ts
@@ -111,4 +111,23 @@ describe('checkContent', () => {
     expect(result.status).toBe(false)
     expect(result.message).toBe('Malicious JavaScript found in content')
   })
+  it('shoukld not flag "confirm scheduling" as malicious', async () => {
+    const wikiWithConfirmScheduling = {
+      id: 'wiki',
+      summary: 'Summary of the wiki',
+      promoted: 0,
+      title: 'wiki',
+      content: 'This is some content with confirm scheduling.',
+      categories: [],
+      tags: [],
+      hidden: false,
+      metadata: [],
+      version: 1,
+      language: 'en',
+    };
+    const result = await service.checkContent(wikiWithConfirmScheduling as unknown as Wiki);
+    console.log(result);
+    expect(result.status).toBe(true);
+    expect(result.message).toBe('Content secure');
+  })
 })

--- a/src/App/utils/utils-spec/securityTester.spec.ts
+++ b/src/App/utils/utils-spec/securityTester.spec.ts
@@ -124,10 +124,12 @@ describe('checkContent', () => {
       metadata: [],
       version: 1,
       language: 'en',
-    };
-    const result = await service.checkContent(wikiWithConfirmScheduling as unknown as Wiki);
-    console.log(result);
-    expect(result.status).toBe(true);
-    expect(result.message).toBe('Content secure');
+    }
+    const result = await service.checkContent(
+      wikiWithConfirmScheduling as unknown as Wiki,
+    )
+    console.log(result)
+    expect(result.status).toBe(true)
+    expect(result.message).toBe('Content secure')
   })
 })


### PR DESCRIPTION
# brainpass security iteration

Wrote test for the brainpass security to ensure that the javascript checker is not flagging javascript keywords in plain text without invocation, example 'confirm scheduling' should not be flagged, 'confirm()' should be flagged.

## Test with: 
yarn test securityTester.spec.ts

https://github.com/EveripediaNetwork/issues/issues/2020
