### PR TITLE
Update the token links on the rank page

### DIFF
--- a/src/App/marketCap/marketcapIds.ts
+++ b/src/App/marketCap/marketcapIds.ts
@@ -80,6 +80,7 @@ export const cryptocurrencyIds = [
   { coingeckoId: 'xdce-crowd-sale', wikiId: 'xdc-network' },
   { coingeckoId: 'bitget-token', wikiId: 'bitget' },
   { coingeckoId: 'paxos-standard', wikiId: 'pax-dollar-usdp' },
+  { coingeckoId: 'nusd', wikiId: 'susd' },
   { coingeckoId: 'tether-gold', wikiId: 'tether-gold-xaut' },
   { coingeckoId: 'compound-ether', wikiId: 'ceth' },
   { coingeckoId: 'gala', wikiId: 'gala-games' },


### PR DESCRIPTION
# PR title goes here

Update of the tokens with incorrect linking on the rank page to ensure the page is opening the right and updated information.

links
linked https://iq.wiki/wiki/susd to the number 20 on the stablecoins rank



https://iq.wiki/rank/stableCoinshttps://github.com/EveripediaNetwork/issues/issues/2098
