### PR TITLE
Upate method invocation regex

### DIFF
--- a/src/App/utils/securityTester.ts
+++ b/src/App/utils/securityTester.ts
@@ -87,8 +87,7 @@ export default class SecurityTestingService {
     const alertObfuscation =
       /\b(alert|a=alert,a|\[1\]\.find\(alert\)|top\["al"\s*\+\s*"ert"\]\(1\)|top\/al\/.source\s*\+\s*\/ert\/.source\(1\)|al\\u0065rt\(1\)|top\['al\\145rt'\]\(1\)|top\['al\\x65rt'\]\(1\)|top\[8680439..toString\(30\)\]\(1\)|alert\?\(\)|`${alert``}`)\b/
 
-    const evalObfuscation =
-      /(^|\W)(alert|eval|prompt|confirm(?!\s+scheduling)((\s*?)?(\?)?\s*?\(|\s+)(.*?)(\s*?)?(\)|;|$|\W))/gi
+    const evalObfuscation = /\b\w+\(\)/gi
 
     const jsURISchemeRegex =
       /(?=.*javascript:|.*data:)(?!(?:['"]?(?:on\w+|style)\s*=|\w+\s*=)\s*(?:\(|&#[xX]28;|%28|['"]?\+?\d))/i


### PR DESCRIPTION
Ensures tester captures only method invocation and not just js keyword methods 
closes https://github.com/EveripediaNetwork/issues/issues/2173
