### PR TITLE
Mutation API for RankPageIdInputs

### DIFF
--- a/src/App/marketCap/marketCap.resolver.ts
+++ b/src/App/marketCap/marketCap.resolver.ts
@@ -4,11 +4,20 @@ import {
   MarketRankData,
   NftRankListData,
   RankPageIdInputs,
-  RankType,
   TokenRankListData,
 } from './marketcap.dto'
 import MarketCapService from './marketCap.service'
-// import { WikiUrl } from '../Wiki/wiki.dto'
+
+function extractSlug(url: string) {
+  // Remove trailing slash if it exists
+  const urlReg = url.replace(/\/$/, '')
+
+  // Split the URL by '/'
+  const parts = urlReg.split('/')
+
+  // Return the last part
+  return parts[parts.length - 1]
+}
 
 @Resolver(() => MarketRankData)
 class MarketCapResolver {
@@ -21,21 +30,17 @@ class MarketCapResolver {
     return this.marketCapService.ranks(args)
   }
 
-  @Mutation(() => Boolean )
-  async rankPageIds(
-    @Args() args: RankPageIdInputs,
-  ): Promise<boolean> {
+  @Mutation(() => Boolean)
+  async rankPageIds(@Args() args: RankPageIdInputs): Promise<boolean> {
     return this.marketCapService.updateMistachIds(args)
   }
 
   @Mutation(() => Boolean)
-  async linkWikiToRankData(
-    @Args() args: RankPageIdInputs,
-  ): Promise<boolean> {
+  async linkWikiToRankData(@Args() args: RankPageIdInputs): Promise<boolean> {
     try {
-      let wikiId = args.wikiId
+      let { wikiId } = args
       if (wikiId.includes('https')) {
-        wikiId = wikiId.split('/wiki/').pop() || ''
+        wikiId = extractSlug(wikiId)
       }
 
       if (!wikiId) {
@@ -44,7 +49,7 @@ class MarketCapResolver {
       }
 
       await this.marketCapService.updateMistachIds({
-        wikiId: wikiId,
+        wikiId,
         coingeckoId: args.coingeckoId,
         kind: args.kind,
       })

--- a/src/App/marketCap/marketCap.resolver.ts
+++ b/src/App/marketCap/marketCap.resolver.ts
@@ -4,9 +4,11 @@ import {
   MarketRankData,
   NftRankListData,
   RankPageIdInputs,
+  RankType,
   TokenRankListData,
 } from './marketcap.dto'
 import MarketCapService from './marketCap.service'
+// import { WikiUrl } from '../Wiki/wiki.dto'
 
 @Resolver(() => MarketRankData)
 class MarketCapResolver {
@@ -24,6 +26,43 @@ class MarketCapResolver {
     @Args() args: RankPageIdInputs,
   ): Promise<boolean> {
     return this.marketCapService.updateMistachIds(args)
+  }
+
+  @Mutation(() => Boolean)
+  async linkWikiToRankData(
+    @Args() args: RankPageIdInputs,
+    @Args('wikiId') wikiId: string,
+    @Args('coingeckoId') coingeckoId: string,
+    @Args('kind') kind: string,
+  ): Promise<boolean> {
+    try {
+      let finalWikiId = wikiId
+      if(wikiId.includes('https')){
+        finalWikiId = wikiId.split('/wiki/').pop() || ''
+      }
+      
+      if(!finalWikiId) {
+        console.error('Invalid wiki ID')
+        return false
+      }
+      const enumKind = RankType[kind as keyof typeof RankType]
+
+      if (!enumKind) {
+        console.error('Invalid kind')
+        return false
+      }
+
+      await this.marketCapService.updateMistachIds({
+        wikiId: finalWikiId,
+        coingeckoId: coingeckoId,
+        kind: enumKind,
+      })
+
+      return true
+    } catch (error) {
+      console.error(error)
+      return false
+    }
   }
 }
 

--- a/src/App/marketCap/marketCap.resolver.ts
+++ b/src/App/marketCap/marketCap.resolver.ts
@@ -9,13 +9,10 @@ import {
 import MarketCapService from './marketCap.service'
 
 function extractSlug(url: string) {
-  // Remove trailing slash if it exists
   const urlReg = url.replace(/\/$/, '')
 
-  // Split the URL by '/'
   const parts = urlReg.split('/')
 
-  // Return the last part
   return parts[parts.length - 1]
 }
 

--- a/src/App/marketCap/marketCap.resolver.ts
+++ b/src/App/marketCap/marketCap.resolver.ts
@@ -31,31 +31,22 @@ class MarketCapResolver {
   @Mutation(() => Boolean)
   async linkWikiToRankData(
     @Args() args: RankPageIdInputs,
-    @Args('wikiId') wikiId: string,
-    @Args('coingeckoId') coingeckoId: string,
-    @Args('kind') kind: string,
   ): Promise<boolean> {
     try {
-      let finalWikiId = wikiId
-      if(wikiId.includes('https')){
-        finalWikiId = wikiId.split('/wiki/').pop() || ''
+      let wikiId = args.wikiId
+      if (wikiId.includes('https')) {
+        wikiId = wikiId.split('/wiki/').pop() || ''
       }
-      
-      if(!finalWikiId) {
-        console.error('Invalid wiki ID')
-        return false
-      }
-      const enumKind = RankType[kind as keyof typeof RankType]
 
-      if (!enumKind) {
-        console.error('Invalid kind')
+      if (!wikiId) {
+        console.error('Invalid wiki ID')
         return false
       }
 
       await this.marketCapService.updateMistachIds({
-        wikiId: finalWikiId,
-        coingeckoId: coingeckoId,
-        kind: enumKind,
+        wikiId: wikiId,
+        coingeckoId: args.coingeckoId,
+        kind: args.kind,
       })
 
       return true

--- a/src/App/marketCap/marketCap.service.ts
+++ b/src/App/marketCap/marketCap.service.ts
@@ -148,6 +148,7 @@ class MarketCapService {
         kind === RankType.TOKEN
           ? {
               image: element.image || '',
+              id: element.id,
               name: element.name || '',
               alias: element.symbol || '',
               current_price: element.current_price || 0,
@@ -158,6 +159,7 @@ class MarketCapService {
             }
           : {
               alias: null,
+              id: element.id,
               name: element.name || '',
               image: element.image?.small || '',
               native_currency: element.native_currency || '',

--- a/src/App/marketCap/marketcap.dto.ts
+++ b/src/App/marketCap/marketcap.dto.ts
@@ -20,6 +20,9 @@ class MarketDataGenerals {
   alias?: string
 
   @Field()
+  id!: string
+
+  @Field()
   hasWiki!: boolean
 
   @Field()

--- a/src/App/marketCap/marketcap.dto.ts
+++ b/src/App/marketCap/marketcap.dto.ts
@@ -128,7 +128,6 @@ export class MarketCapInputs extends PaginationArgs {
 @ArgsType()
 export class RankPageIdInputs {
   @Field(() => String)
-  @Validate(ValidStringParams)
   wikiId!: string
 
   @Field(() => String)


### PR DESCRIPTION
Rank page API Update

API for admin panel, takes in wiki url and automatically links with the coingecko listing at that level, no need for coingecko apiId. It updates if it already exists, or creates the link if it doesn't.

``` gql
mutation {
      linkWikiToRankData (
            coingeckoIdd: "lista-dao"
            kind: TOKEN
            wikiId: "listadao"
    )
 }
```
OR

``` gql
mutation {
      linkWikiToRankData (
            coingeckoIdd: "lista-dao"
            kind: TOKEN
            wikiId: "https://iq.wiki/wiki/listadao/"
    )
 }
```
 closes https://github.com/EveripediaNetwork/issues/issues/3062
