### PR TITLE
Update wiki categories api to filter with tags

### DIFF
--- a/src/App/Wiki/wiki.dto.ts
+++ b/src/App/Wiki/wiki.dto.ts
@@ -37,6 +37,10 @@ export class CategoryArgs extends LangArgs {
   @Field(() => String)
   @Validate(ValidStringParams)
   category!: string
+
+  @Field(() => [String], { nullable: true })
+  @Validate(ValidStringParams)
+  tagIds?: string[]
 }
 
 @ArgsType()


### PR DESCRIPTION

_Additional tag filter untop of categories_

## How should this be tested?

1. 
```gql
{
  wikisByCategory(category: "cryptocurrencies", tagIds: ["ai"]) {
    id
    tags {
      id
    }
  }
}
```
2.
```gql
{
  wikisByCategory(category: "cryptocurrencies", tagIds: ["ai", "developers"]) {
    id
    tags {
      id
    }
  }
}
```


## Linked issues

parts of https://github.com/EveripediaNetwork/issues/issues/3040
