### PR TITLE
Resolve ethers underflow error

### DIFF
--- a/src/Relayer/services/relayer.service.ts
+++ b/src/Relayer/services/relayer.service.ts
@@ -92,9 +92,9 @@ class RelayerService {
   async getUpdatedGas() {
     const maticGas = (await this.getMaticGas()) || '40'
 
-    const gasBump = parseInt(maticGas, 10) * 1.2
+    const gasBump = String(Math.round(parseInt(maticGas, 10) * 1.2))
 
-    return String(gasBump)
+    return gasBump
   }
 
   public async relayTx(


### PR DESCRIPTION
# Relayer bug

_Excess decimal places from parseInt caused the underflow error_

<img width="1460" alt="image" src="https://github.com/user-attachments/assets/cbc79d58-7d90-40d3-b753-cc9d56e2983d">

## Notes or observations

_jot down something here_

## Linked issues

 closes https://github.com/EveripediaNetwork/issues/issues/3106
