### PR TITLE
Rankpage bug

### DIFF
--- a/src/App/app.module.ts
+++ b/src/App/app.module.ts
@@ -73,7 +73,7 @@ import WikiController from './Wiki/controllers/wiki.controller'
     ConfigModule.forRoot({
       isGlobal: true,
     }),
-    CacheModule.register({ ttl: 3600 }),
+    CacheModule.register({ ttl: 3600, max: 10000, isGlobal: true }),
     GraphQLModule.forRoot<ApolloDriverConfig>({
       driver: ApolloDriver,
       debug: true,

--- a/src/App/utils/discordWebhookHandler.ts
+++ b/src/App/utils/discordWebhookHandler.ts
@@ -133,7 +133,7 @@ export default class WebhookHandler {
           {
             color: 0xff9900,
             title: `📢   Wiki report on ${payload?.urlId}  📢`,
-            url: `${this.getWebpageUrl()}wiki/${payload?.urlId}`,
+            url: `${this.getWebpageUrl()}/wiki/${payload?.urlId}`,
             description: `${payload?.description}`,
             footer: {
               text: `Flagged by ${user?.username || 'user'}`,


### PR DESCRIPTION
# Rankpage bug

1. _Uses only selected fields required by rankpage_
2. _Ensures that on page load, only a max of 50 points per rank list is returned, and automatically filling up data for rank page search is disabled_
3. _Cache size has been increased_

## Notes or observations

_Promise.all used for filling up cache data(1k+ rows) for search was causing a thundering herd (concurrent DB queries)_
_Cache overwrites lru once size is exceeded_


## Linked issues

closes https://github.com/EveripediaNetwork/issues/issues/3103
