### PR TITLE
Retry mechanism for failed revalidation

### DIFF
--- a/src/App/revalidatePage/revalidatePage.service.ts
+++ b/src/App/revalidatePage/revalidatePage.service.ts
@@ -6,7 +6,7 @@ import { Cache } from 'cache-manager'
 import { RankType } from '../marketCap/marketcap.dto'
 import Category from '../../Database/Entities/category.entity'
 import Wiki from '../../Database/Entities/wiki.entity'
-import { Cron } from '@nestjs/schedule'
+import { Cron, CronExpression } from '@nestjs/schedule'
 
 export enum RevalidateEndpoints {
   HIDE_WIKI = 'hideWiki',
@@ -75,7 +75,7 @@ export class RevalidatePageService {
     return true
   }
 
-  @Cron('*/5****')
+  @Cron(CronExpression.EVERY_5_SECONDS)
   async retryFailedUrl() {
     if (this.failedUrls.length > 0) {
       console.log('Retrying failed URLs...')

--- a/src/App/revalidatePage/revalidatePage.service.ts
+++ b/src/App/revalidatePage/revalidatePage.service.ts
@@ -87,7 +87,7 @@ export class RevalidatePageService {
     const now = new Date()
     if (this.failedUrls.length > 0) {
       console.log('Retrying failed URLs...')
-      await Promise.all(
+      const updatedFailedUrls = await Promise.all(
         this.failedUrls.map(async (failedUrlObj) => {
           if (failedUrlObj.retries >= this.maxRetries) {
             console.log(
@@ -114,7 +114,7 @@ export class RevalidatePageService {
           }
         }),
       )
-      this.failedUrls = this.failedUrls.filter(Boolean)
+      this.failedUrls = updatedFailedUrls.filter((url): url is NonNullable<typeof url> => url !== null && url.retries < this.maxRetries)
     }
   }
 

--- a/src/App/revalidatePage/revalidatePage.service.ts
+++ b/src/App/revalidatePage/revalidatePage.service.ts
@@ -70,7 +70,11 @@ export class RevalidatePageService {
         'Error revalidating path',
         e.response?.config?.url || e.message,
       )
-      this.failedUrls.push({url: e.response?.config?.url, retries: 0, nextRetry: new Date(),})
+      this.failedUrls.push({
+        url: e.response?.config?.url,
+        retries: 0,
+        nextRetry: new Date(),
+      })
     }
 
     return true

--- a/src/App/revalidatePage/revalidatePage.service.ts
+++ b/src/App/revalidatePage/revalidatePage.service.ts
@@ -67,7 +67,7 @@ export class RevalidatePageService {
     ]
 
     await Promise.all(
-      urlsToRevalidate.map(async urlToRevalidate => {
+      urlsToRevalidate.map(async (urlToRevalidate) => {
         try {
           await this.httpService.get(urlToRevalidate).toPromise()
         } catch (e: any) {


### PR DESCRIPTION
# Retry mechanism for failed revalidation
_Prevent pages from being ignored after revalidation fails, we need a way to retry the revalidations for those failed pages_


closes https://github.com/EveripediaNetwork/issues/issues/3090