### PR TITLE
Explorers api

### DIFF
--- a/src/App/Wiki/wiki.resolver.ts
+++ b/src/App/Wiki/wiki.resolver.ts
@@ -33,6 +33,7 @@ import PageviewsPerDay from '../../Database/Entities/pageviewsPerPage.entity'
 import { PageViewArgs, VistArgs } from '../pageViews/pageviews.dto'
 import { updateDates } from '../utils/queryHelpers'
 import { eventWiki } from '../Tag/tag.dto'
+import Explorer from '../../Database/Entities/explorer.entity'
 
 @UseInterceptors(AdminLogsInterceptor)
 @Resolver(() => Wiki)
@@ -100,6 +101,17 @@ class WikiResolver {
   @Query(() => Count)
   async categoryTotal(@Args() args: CategoryArgs) {
     return this.wikiService.getCategoryTotal(args)
+  }
+
+  @Query(() => [Explorer])
+  async searchExplorers(@Args() args: ByIdArgs) {
+    return this.wikiService.getExplorers(args.id)
+  }
+
+  @Mutation(() => Boolean, { nullable: true })
+  @UseGuards(AuthGuard)
+  async updateExplorers(@Args() args: Explorer) {
+    return this.wikiService.addExplorer(args)
   }
 
   @Mutation(() => Wiki, { nullable: true })

--- a/src/Database/Entities/explorer.entity.ts
+++ b/src/Database/Entities/explorer.entity.ts
@@ -1,0 +1,19 @@
+import { Column, Entity, PrimaryColumn } from 'typeorm'
+import { ArgsType, Field, ID, ObjectType } from '@nestjs/graphql'
+
+@ObjectType()
+@ArgsType()
+@Entity()
+class Explorer {
+  @Field(() => ID)
+  @PrimaryColumn('varchar', {
+    length: 255,
+  })
+  id!: string
+
+  @Field(() => String)
+  @Column('varchar')
+  baseUrl!: string
+}
+
+export default Explorer

--- a/src/Database/database.module.ts
+++ b/src/Database/database.module.ts
@@ -21,6 +21,7 @@ import IQHolderAddress from './Entities/iqHolderAddress.entity'
 import IQHolder from './Entities/iqHolder.entity'
 import MarketCapIds from './Entities/marketCapIds.entity'
 import Events from './Entities/Event.entity'
+import Explorer from './Entities/explorer.entity'
 
 @Module({
   imports: [
@@ -54,6 +55,7 @@ import Events from './Entities/Event.entity'
           IQHolderAddress,
           MarketCapIds,
           Events,
+          Explorer
         ],
         synchronize: true,
         keepConnectionAlive: true,


### PR DESCRIPTION
# API for addition of explorers from admin panel


## How should this be tested?

1. retrieve explorers (search based)
```gql
{
  searchExplorers(id: "line") {
    id
    baseUrl
  }
}
```
2. Add explorer
```gql
mutation {
  updateExplorers(id: "ethscan", baseUrl: "https://etherscan.io/")
}
```


## Linked issues

parts of  https://github.com/EveripediaNetwork/issues/issues/3058
