### PR TITLE
Update wikisCreated & wikisEdited logic

### DIFF
--- a/src/App/User/user.dto.ts
+++ b/src/App/User/user.dto.ts
@@ -1,7 +1,17 @@
-import { ArgsType, Field } from '@nestjs/graphql'
+/* eslint-disable import/no-cycle */
+/* eslint-disable no-underscore-dangle */
+/* eslint-disable max-classes-per-file */
+import {
+  ArgsType,
+  createUnionType,
+  Field,
+  Int,
+  ObjectType,
+} from '@nestjs/graphql'
 import { Validate, MinLength } from 'class-validator'
 import PaginationArgs from '../pagination.args'
 import ValidStringParams from '../utils/customValidator'
+import Activity from '../../Database/Entities/activity.entity'
 
 @ArgsType()
 export class UserStateArgs {
@@ -30,10 +40,36 @@ export class UsersByEditArgs extends PaginationArgs {
 @ArgsType()
 export class GetProfileArgs {
   @Field({ nullable: true })
-    @Validate(ValidStringParams)
+  @Validate(ValidStringParams)
   id?: string
 
   @Field({ nullable: true })
-    @Validate(ValidStringParams)
+  @Validate(ValidStringParams)
   username?: string
 }
+
+@ObjectType()
+export class WikiCount {
+  @Field(() => Int, { defaultValue: 0 })
+  count!: number
+}
+
+@ObjectType()
+export class UserActivity {
+  @Field(() => [Activity], { nullable: true })
+  activity!: Activity[]
+}
+
+export const UserWikis = createUnionType({
+  name: 'UserWikis',
+  types: () => [UserActivity, WikiCount] as const,
+  resolveType(value) {
+    if (value.activity) {
+      return 'UserActivity'
+    }
+    if (value.count) {
+      return 'WikiCount'
+    }
+    return null
+  },
+})

--- a/src/App/User/user.resolver.ts
+++ b/src/App/User/user.resolver.ts
@@ -114,22 +114,34 @@ class UserResolver {
   }
 
   @ResolveField()
-  async wikisCreated(@Parent() user: IUser, @Args() args: PaginationArgs) {
+  async wikisCreated(
+    @Parent() user: IUser,
+    @Args() args: PaginationArgs,
+    @Context() context: any,
+  ) {
+    const { query } = context.req.body
     return this.userService.userWikis(
       'wikis created',
       user?.id as string,
       args.limit,
       args.offset,
+      query,
     )
   }
 
   @ResolveField()
-  async wikisEdited(@Parent() user: IUser, @Args() args: PaginationArgs) {
+  async wikisEdited(
+    @Parent() user: IUser,
+    @Args() args: PaginationArgs,
+    @Context() context: any,
+  ) {
+    const { query } = context.req.body
     return this.userService.userWikis(
       'wikis edited',
       user?.id as string,
       args.limit,
       args.offset,
+      query,
     )
   }
 

--- a/src/App/User/user.service.ts
+++ b/src/App/User/user.service.ts
@@ -242,7 +242,7 @@ class UserService {
     const isWikiCount = hasField(ast, 'users', {
       fragmentType: 'WikiCount',
     })
-    console.log(isWikiCount)
+
     const wikis =
       type === 'wikis created'
         ? queryWikisCreated(id, limit, offset, repo, isWikiCount)

--- a/src/App/User/userProfile.resolver.ts
+++ b/src/App/User/userProfile.resolver.ts
@@ -66,12 +66,15 @@ class UserProfileResolver {
   async wikisCreated(
     @Parent() user: GetProfileArgs,
     @Args() args: PaginationArgs,
+    @Context() context: any,
   ) {
+    const { query } = context.req.body
     return this.userService.userWikis(
       'wikis created',
       user?.id as string,
       args.limit,
       args.offset,
+      query,
     )
   }
 
@@ -79,12 +82,15 @@ class UserProfileResolver {
   async wikisEdited(
     @Parent() user: GetProfileArgs,
     @Args() args: PaginationArgs,
+    @Context() context: any,
   ) {
+    const { query } = context.req.body
     return this.userService.userWikis(
       'wikis edited',
       user?.id as string,
       args.limit,
       args.offset,
+      query,
     )
   }
 

--- a/src/App/Wiki/wiki.dto.ts
+++ b/src/App/Wiki/wiki.dto.ts
@@ -101,6 +101,7 @@ export class EventArgs extends EventDefaultArgs {
   @Validate(ValidStringParams)
   country?: string
 }
+
 @ArgsType()
 export class EventByTitleArgs extends EventDefaultArgs {
   @Field(() => String, { nullable: true })
@@ -113,41 +114,28 @@ export class EventByCategoryArgs extends EventDefaultArgs {
   @Validate(ValidStringParams)
   category?: string
 }
-@ArgsType()
-export class EventByBlockchainArgs extends EventDefaultArgs {
-  @Field(() => String, { nullable: true })
-  @Validate(ValidStringParams)
-  blockchain?: string
-}
 
-@ArgsType()
-export class EventByLocationArgs extends EventDefaultArgs {
-  @Field(() => String, { nullable: true })
-  @Validate(ValidStringParams)
-  continent?: string
-
-  @Field(() => String, { nullable: true })
-  @Validate(ValidStringParams)
-  country?: string
-}
-
-export function hasField(ast: any, fieldName: string): boolean {
+export function hasField(
+  ast: any,
+  fieldName: string,
+  options?: { fragmentType: string },
+): boolean {
   let fieldExists = false
 
-  function traverse(node: {
-    kind: string
-    name: { value: string }
-    selectionSet: { selections: any[] }
-  }) {
-    if (node.kind === 'Field' && node.name.value === fieldName) {
+  function traverse(node: any) {
+    if (node.kind === 'Field' && node.name.value === fieldName && !options) {
       fieldExists = true
-    }
-
-    if (node.selectionSet) {
+    } else if (node.kind === 'InlineFragment' && options?.fragmentType) {
+      if (
+        node.typeCondition &&
+        node.typeCondition.name.value === options.fragmentType
+      ) {
+        fieldExists = true
+      }
+    } else if (node.selectionSet) {
       node.selectionSet.selections.forEach(traverse)
     }
   }
-
   ast.definitions.forEach((definition: any) => {
     traverse(definition)
   })

--- a/src/App/utils/queryHelpers.ts
+++ b/src/App/utils/queryHelpers.ts
@@ -2,6 +2,7 @@ import { Repository } from 'typeorm'
 import Activity from '../../Database/Entities/activity.entity'
 import { OrderBy, Direction, IntervalByDays } from '../general.args'
 import { VistArgs } from '../pageViews/pageviews.dto'
+import { UserActivity, WikiCount } from '../User/user.dto'
 
 export const orderWikis = (order: OrderBy, direction: Direction) => {
   let sortValue = {}
@@ -37,46 +38,80 @@ export const queryWikisCreated = async (
   limit: number,
   offset: number,
   repo: Repository<Activity>,
-): Promise<Activity[] | undefined> =>
-  repo
+  count = false,
+): Promise<UserActivity | WikiCount> => {
+  const query = repo
     .createQueryBuilder('activity')
     .leftJoin('wiki', 'w', 'w."id" = activity.wikiId')
     .where('LOWER(activity.userId) = :id AND w."hidden" = false', {
       id: id?.toLowerCase(),
     })
     .andWhere("activity.type = '0'")
+
+  if (count) {
+    const result = await query
+      .select('Count(activity.wikiId)', 'amount')
+      .getRawMany()
+    return { count: result[0].amount } as WikiCount
+  }
+
+  const activity = await query
     .groupBy('activity.wikiId, activity.id')
     .limit(limit)
     .offset(offset)
     .orderBy('datetime', 'DESC')
     .getMany()
 
+  return { activity } as UserActivity
+}
+
 export const queryWikisEdited = async (
   id: string,
   limit: number,
   offset: number,
   repo: Repository<Activity>,
-): Promise<Activity[] | undefined> =>
-  repo.query(
+  count = false,
+): Promise<UserActivity | WikiCount> => {
+  const subquery = `
+            FROM (
+                SELECT "wikiId", MAX(datetime) AS MaxDate  
+                FROM activity
+                WHERE type = '1' AND LOWER("activity"."userId") = LOWER($1)
+                GROUP BY "activity"."wikiId"
+            ) r
+            INNER JOIN "activity" d
+            ON d."wikiId" = r."wikiId" AND d.datetime = r.MaxDate
+            INNER JOIN "wiki" w
+            ON w."id" = d."wikiId"
+            WHERE w."hidden" = false
     `
-    SELECT d."wikiId", d."ipfs", d."type", d."content", d."userId", d."id", d."datetime" FROM
-        (
-            SELECT "wikiId", Max(datetime) as MaxDate  
-            FROM activity
-            WHERE type = '1' AND "activity"."userId" = $1
-            GROUP BY "activity"."wikiId"
-        ) r
-        INNER JOIN "activity" d
-        ON d."wikiId"=r."wikiId" AND d.datetime=r.MaxDate
-        INNER JOIN "wiki" w
-        ON w."id" = d."wikiId"
-        WHERE w."hidden" = false
+  if (count) {
+    const result = await repo.query(
+      `
+        SELECT COUNT(results."wikiId") AS edits
+        FROM (
+            SELECT d."wikiId", d."type", d."userId", d."id"
+            ${subquery}
+        ) AS results;
+      `,
+      [id],
+    )
+
+    return { count: result[0].edits } as WikiCount
+  }
+  const activities = await repo.query(
+    `
+        SELECT d."wikiId", d."ipfs", d."type", d."content", d."userId", d."id", d."datetime" 
+        ${subquery}  
         ORDER BY d."datetime" DESC
         LIMIT $2
         OFFSET $3
-    `,
+  
+      `,
     [id, limit, offset],
   )
+  return { activity: activities } as UserActivity
+}
 
 export const updateDates = async (args: VistArgs) => {
   const { interval } = args

--- a/src/Database/Entities/user.entity.ts
+++ b/src/Database/Entities/user.entity.ts
@@ -14,8 +14,8 @@ import { Field, ID, ObjectType } from '@nestjs/graphql'
 import { IUser } from './types/IUser'
 import { IWiki } from './types/IWiki'
 import Wiki from './wiki.entity'
-import Activity from './activity.entity'
 import UserProfile from './userProfile.entity'
+import { UserWikis, UserActivity, WikiCount } from '../../App/User/user.dto'
 
 @ObjectType()
 @Entity()
@@ -40,11 +40,11 @@ class User implements IUser {
   @OneToMany(() => Wiki, wiki => wiki.user, { lazy: true })
   wikis!: Relation<IWiki>[]
 
-  @Field(() => [Activity])
-  wikisCreated!: Activity[]
+  @Field(() => UserWikis)
+  wikisCreated!: UserActivity | WikiCount
 
-  @Field(() => [Activity])
-  wikisEdited!: Activity[]
+  @Field(() => UserWikis)
+  wikisEdited!: UserActivity | WikiCount
 }
 
 export default User

--- a/src/Database/Entities/userProfile.entity.ts
+++ b/src/Database/Entities/userProfile.entity.ts
@@ -14,9 +14,9 @@ import {
   ObjectType,
 } from '@nestjs/graphql'
 import { Links, Notifications, AdvancedSettings } from './types/IUser'
-import Activity from './activity.entity'
 import Wiki from './wiki.entity'
 import skipMiddleware from './middlewares/skipMiddleware'
+import { UserActivity, UserWikis, WikiCount } from '../../App/User/user.dto'
 
 @ObjectType()
 @Entity()
@@ -95,11 +95,11 @@ class UserProfile {
   @Field(() => Boolean)
   active!: boolean
 
-  @Field(() => [Activity])
-  wikisCreated!: Activity[]
+  @Field(() => UserWikis)
+  wikisCreated!: UserActivity | WikiCount
 
-  @Field(() => [Activity])
-  wikisEdited!: Activity[]
+  @Field(() => UserWikis)
+  wikisEdited!: UserActivity | WikiCount
 
   @Field(() => [Wiki])
   wikiSubscribed!: Wiki[]


### PR DESCRIPTION


_Breaking changes, resolve field for `wikisCreated` and `wikisEdited` now uses a union type to return either the total count for that object or it's content_

## How should this be tested?

1. Get user created/edited wiki activity
 
```gql
{
  users(limit: 30, edits: true) {
    id
    profile {
      wikisCreated {
        ...on UserActivity {
          activity {
            id
            wikiId
            ipfs
          }
        }
      }
      wikisEdited {
        ...on UserActivity {
          activity {
            id
            wikiId
            ipfs
          }
        }
      }
    }
  }
}
```

2. Get user total created/edited wiki activity

```gql
{
  users(limit: 30, edits: true) {
    id
    profile {
      wikisCreated {
        ...on WikiCount {
          count
        }
      }
      wikisEdited {
        ...on WikiCount {
          count 
        }
      }
    }
  }
}
```

## Notes or observations

cc @invisiblemask 

## Linked issues

parts of https://github.com/EveripediaNetwork/issues/issues/3220
