### PR TITLE
Adds resolver for hiiq stats by token rank, updates indexing logic to track tokens staked

### DIFF
--- a/src/App/HiIQHolders/hiIQHolder.repository.ts
+++ b/src/App/HiIQHolders/hiIQHolder.repository.ts
@@ -1,41 +1,11 @@
 import { Injectable } from '@nestjs/common'
 import { DataSource, Repository } from 'typeorm'
 import HiIQHolder from '../../Database/Entities/hiIQHolder.entity'
-import HiIQHolderArgs from './hiIQHolders.dto'
-import { IntervalByDays } from '../general.args'
 
 @Injectable()
 class HiIQHolderRepository extends Repository<HiIQHolder> {
   constructor(private dataSource: DataSource) {
     super(HiIQHolder, dataSource.createEntityManager())
-  }
-
-  async getHiIQHoldersCount(args: HiIQHolderArgs): Promise<HiIQHolder[]> {
-    if (args.interval !== IntervalByDays.DAY) {
-      return this.query(
-        `
-            WITH RankedData AS (
-            SELECT
-                amount, day,
-                ROW_NUMBER() OVER (ORDER BY day) AS row_num
-            FROM hi_iq_holder
-            )
-            SELECT amount, day
-            FROM RankedData
-            WHERE (row_num - 1) % $1 = 0
-            ORDER BY day
-            OFFSET $2
-            LIMIT $3;
-        `,
-        [args.interval, args.offset, args.limit],
-      )
-    }
-    return this.createQueryBuilder('hi_iq_holder')
-      .select('amount')
-      .addSelect('day')
-      .offset(args.offset)
-      .limit(args.limit)
-      .getRawMany()
   }
 }
 

--- a/src/App/HiIQHolders/hiIQHolder.resolver.ts
+++ b/src/App/HiIQHolders/hiIQHolder.resolver.ts
@@ -1,15 +1,22 @@
 import { Args, Query, Resolver } from '@nestjs/graphql'
 import HiIQHolder from '../../Database/Entities/hiIQHolder.entity'
-import HiIQHolderRepository from './hiIQHolder.repository'
 import HiIQHolderArgs from './hiIQHolders.dto'
+import HiIQHolderService from './hiIQHolder.service'
+import HiIQHolderAddress from '../../Database/Entities/hiIQHolderAddress.entity'
+import { OrderArgs } from '../pagination.args'
 
 @Resolver(() => HiIQHolder)
 class HiIQHoldersResolver {
-  constructor(private hiIQHoldersRepository: HiIQHolderRepository) {}
+  constructor(private hiIQHoldersService: HiIQHolderService) {}
 
   @Query(() => [HiIQHolder], { name: 'hiIQHolders' })
   async hiIQHolders(@Args() args: HiIQHolderArgs) {
-    return this.hiIQHoldersRepository.getHiIQHoldersCount(args)
+    return this.hiIQHoldersService.getHiIQHoldersCount(args)
+  }
+
+  @Query(() => [HiIQHolderAddress], { name: 'hiIQHoldersRank' })
+  async hiIQHoldersRank(@Args() args: OrderArgs) {
+    return this.hiIQHoldersService.hiIQHoldersRank(args)
   }
 }
 

--- a/src/App/Treasury/treasury.dto.ts
+++ b/src/App/Treasury/treasury.dto.ts
@@ -13,4 +13,4 @@ export const dateOnly = (date: Date) => {
 }
 
 export const firstLevelNodeProcess = () =>
-  parseInt(process.env.NODE_APP_INSTANCE as string, 10) === 0
+  Number(process.env.pm_id) === 0 || !process.env.pm_id

--- a/src/Database/Entities/hiIQHolderAddress.entity.ts
+++ b/src/Database/Entities/hiIQHolderAddress.entity.ts
@@ -1,4 +1,4 @@
-import { Field, GraphQLISODateTime, ID, ObjectType } from '@nestjs/graphql'
+import { Field, GraphQLISODateTime, ObjectType } from '@nestjs/graphql'
 import {
   Entity,
   Column,
@@ -10,7 +10,6 @@ import {
 @ObjectType()
 @Entity()
 class HiIQHolderAddress {
-  @Field(() => ID)
   @PrimaryGeneratedColumn()
   id!: number
 
@@ -19,6 +18,10 @@ class HiIQHolderAddress {
     unique: true,
   })
   address!: string
+
+  @Field(() => String)
+  @Column({ type: 'numeric', precision: 78, scale: 0 })
+  tokens!: string
 
   @Field(() => GraphQLISODateTime)
   @CreateDateColumn()


### PR DESCRIPTION


# Index HiIQ holder stats from contract logs

_Adds resolver for hiiq stats by token rank, updates indexing logic to track tokens staked_
_228 holders currently_


## How should this be tested?

1.
```gql
{
  hiIQHoldersRank {
    id
    address
    tokens
  }
}
```


## Linked issues

closes https://github.com/EveripediaNetwork/issues/issues/3324
