### PR TITLE
SearchhiIQHoldersByAddress API

### DIFF
--- a/src/App/HiIQHolders/hiIQHolder.resolver.ts
+++ b/src/App/HiIQHolders/hiIQHolder.resolver.ts
@@ -23,6 +23,11 @@ class HiIQHoldersResolver {
   async hiIQHoldersRank(@Args() args: OrderArgs) {
     return this.hiIQHoldersService.hiIQHoldersRank(args)
   }
+
+  @Query(() => HiIQHolderAddress, { name: 'searchHiIQHolder', nullable: true })
+  async searchHiIQHolderAddress(@Args('address') address: string) {
+    return this.hiIQHoldersService.searchHiIQHolderAddress(address)
+  }
 }
 
 export default HiIQHoldersResolver

--- a/src/App/HiIQHolders/hiIQHolder.resolver.ts
+++ b/src/App/HiIQHolders/hiIQHolder.resolver.ts
@@ -24,7 +24,7 @@ class HiIQHoldersResolver {
     return this.hiIQHoldersService.hiIQHoldersRank(args)
   }
 
-  @Query(() => [HiIQHolderAddress], { name: 'searchHiIQHoldersByAddress', nullable: true })
+  @Query(() => HiIQHolderAddress, { name: 'searchHiIQHoldersByAddress', nullable: true })
   async searchHiIQHoldersByAddress(@Args('address') address: string) {
     return this.hiIQHoldersService.searchHiIQHoldersByAddress(address)
   }

--- a/src/App/HiIQHolders/hiIQHolder.resolver.ts
+++ b/src/App/HiIQHolders/hiIQHolder.resolver.ts
@@ -24,9 +24,9 @@ class HiIQHoldersResolver {
     return this.hiIQHoldersService.hiIQHoldersRank(args)
   }
 
-  @Query(() => HiIQHolderAddress, { name: 'searchHiIQHolder', nullable: true })
-  async searchHiIQHolderAddress(@Args('address') address: string) {
-    return this.hiIQHoldersService.searchHiIQHolderAddress(address)
+  @Query(() => [HiIQHolderAddress], { name: 'searchHiIQHoldersByAddress', nullable: true })
+  async searchHiIQHoldersByAddress(@Args('address') address: string) {
+    return this.hiIQHoldersService.searchHiIQHoldersByAddress(address)
   }
 }
 

--- a/src/App/HiIQHolders/hiIQHolder.service.ts
+++ b/src/App/HiIQHolders/hiIQHolder.service.ts
@@ -24,7 +24,7 @@ export const hiIQCOntract = '0x1bF5457eCAa14Ff63CC89EFd560E251e814E16Ba'
 
 export function checkDisableCondition(): boolean {
   console.log(process.env)
-  return JSON.parse(process.env.REINDEX_HIIQ_HOLDERS as string) as boolean
+  return JSON.parse(process.env.REINDEX_HIIQ_HOLDERS || 'false') as boolean
 }
 
 export type MethodType = {
@@ -56,7 +56,7 @@ class HiIQHolderService implements OnModuleInit {
 
   async onModuleInit() {
     setTimeout(() => {
-      const reIndex = JSON.parse(process.env.REINDEX_HIIQ_HOLDERS as string)
+      const reIndex = JSON.parse(process.env.REINDEX_HIIQ_HOLDERS || 'false')
       if (!reIndex) {
         const job = this.schedulerRegistry.getCronJob('reIndexHiIQHolders')
         job.stop()
@@ -90,7 +90,7 @@ class HiIQHolderService implements OnModuleInit {
   }
 
   checkDisableCondition() {
-    JSON.parse(process.env.REINDEX_HIIQ_HOLDERS as string) as boolean
+    JSON.parse(process.env.REINDEX_HIIQ_HOLDERS || 'false') as boolean
   }
 
   @Cron(CronExpression.EVERY_10_SECONDS, {
@@ -306,6 +306,14 @@ class HiIQHolderService implements OnModuleInit {
       .orderBy('created', 'DESC')
       .limit(1)
       .getMany()
+  }
+
+  async searchHiIQHolderAddress(address: string): Promise<HiIQHolderAddress | null> {
+    return this.hiIQHoldersAddressRepo.findOne({
+      where: {
+        address: address.toLowerCase(),
+      },
+    })
   }
 }
 export default HiIQHolderService

--- a/src/App/HiIQHolders/hiIQHolder.service.ts
+++ b/src/App/HiIQHolders/hiIQHolder.service.ts
@@ -307,13 +307,16 @@ class HiIQHolderService implements OnModuleInit {
       .limit(1)
       .getMany()
   }
-
-  async searchHiIQHolderAddress(address: string): Promise<HiIQHolderAddress | null> {
-    return this.hiIQHoldersAddressRepo.findOne({
-      where: {
-        address: address.toLowerCase(),
-      },
-    })
+  
+  async searchHiIQHoldersByAddress(address: string): Promise<HiIQHolderAddress[]> {
+    const normalizedAddress = address.toLowerCase();
+    
+    return this.hiIQHoldersAddressRepo
+      .createQueryBuilder('hi_iq_holder_address')
+      .where('LOWER(address) = LOWER(:address)', { 
+        address: normalizedAddress 
+      })
+      .getMany();
   }
 }
 export default HiIQHolderService

--- a/src/App/HiIQHolders/hiIQHolder.service.ts
+++ b/src/App/HiIQHolders/hiIQHolder.service.ts
@@ -310,15 +310,21 @@ class HiIQHolderService implements OnModuleInit {
 
   async searchHiIQHoldersByAddress(
     address: string,
-  ): Promise<HiIQHolderAddress[]> {
+  ): Promise<HiIQHolderAddress | null> {
     const normalizedAddress = address.toLowerCase()
 
-    return this.hiIQHoldersAddressRepo
+    const hiIQHolderAddress = await this.hiIQHoldersAddressRepo
       .createQueryBuilder('hi_iq_holder_address')
       .where('LOWER(address) = LOWER(:address)', {
         address: normalizedAddress,
       })
-      .getMany()
+      .getOne()
+
+    if (!hiIQHolderAddress) {
+      return null
+    }
+
+    return hiIQHolderAddress
   }
 }
 export default HiIQHolderService

--- a/src/App/HiIQHolders/hiIQHolder.service.ts
+++ b/src/App/HiIQHolders/hiIQHolder.service.ts
@@ -48,8 +48,6 @@ class HiIQHolderService {
     return this.configService.get<string>('etherScanApiKey') as string
   }
 
-
-
   async lastHolderRecord(): Promise<HiIQHolder[]> {
     return this.hiIQHoldersRepo.find({
       order: {
@@ -75,12 +73,8 @@ class HiIQHolderService {
     }
   }
 
-  checkDisableCondition() {
-    JSON.parse(process.env.REINDEX_HIIQ_HOLDERS as string) as boolean
-  }
-
-  @Cron(CronExpression.EVERY_10_SECONDS, {
-    name: 'reIndexHiIQHolders',
+  @Cron(CronExpression.EVERY_5_SECONDS, {
+    name: 'storeHiIQHolderCount',
   })
   async storeHiIQHolderCount() {
     const job = this.schedulerRegistry.getCronJob('storeHiIQHolderCount')

--- a/src/App/HiIQHolders/hiIQHolder.service.ts
+++ b/src/App/HiIQHolders/hiIQHolder.service.ts
@@ -307,16 +307,18 @@ class HiIQHolderService implements OnModuleInit {
       .limit(1)
       .getMany()
   }
-  
-  async searchHiIQHoldersByAddress(address: string): Promise<HiIQHolderAddress[]> {
-    const normalizedAddress = address.toLowerCase();
-    
+
+  async searchHiIQHoldersByAddress(
+    address: string,
+  ): Promise<HiIQHolderAddress[]> {
+    const normalizedAddress = address.toLowerCase()
+
     return this.hiIQHoldersAddressRepo
       .createQueryBuilder('hi_iq_holder_address')
-      .where('LOWER(address) = LOWER(:address)', { 
-        address: normalizedAddress 
+      .where('LOWER(address) = LOWER(:address)', {
+        address: normalizedAddress,
       })
-      .getMany();
+      .getMany()
   }
 }
 export default HiIQHolderService

--- a/src/App/HiIQHolders/hiIQHolder.service.ts
+++ b/src/App/HiIQHolders/hiIQHolder.service.ts
@@ -5,9 +5,8 @@ import { Injectable } from '@nestjs/common'
 import { Cron, CronExpression, SchedulerRegistry } from '@nestjs/schedule'
 import { HttpService } from '@nestjs/axios'
 import { ConfigService } from '@nestjs/config'
-import { decodeEventLog } from 'viem'
+import { decodeEventLog, erc20Abi } from 'viem'
 import { ethers } from 'ethers'
-import Decimal from 'decimal.js'
 import HiIQHolderRepository from './hiIQHolder.repository'
 import HiIQHolder from '../../Database/Entities/hiIQHolder.entity'
 import HiIQHolderAddressRepository from './hiIQHolderAddress.repository'
@@ -26,6 +25,7 @@ export type MethodType = {
   args: {
     provider: string
     type?: bigint
+    ts?: bigint
     value?: bigint
   }
 }
@@ -40,7 +40,7 @@ class HiIQHolderService {
     private schedulerRegistry: SchedulerRegistry,
   ) {}
 
-  private provider(): string {
+  private providerUrl(): string {
     return this.configService.get<string>('PROVIDER_NETWORK') as string
   }
 
@@ -108,6 +108,8 @@ class HiIQHolderService {
         ? await this.getOldLogs(previous, next)
         : await this.getOldLogs()
 
+    const rpcProvider = new ethers.providers.JsonRpcProvider(this.providerUrl())
+
     if (logs.length !== 0) {
       for (const log of logs) {
         try {
@@ -116,20 +118,50 @@ class HiIQHolderService {
             data: log.data,
             topics: log.topics,
           }) as unknown as MethodType
-          if (decodelog.eventName === 'Deposit' && decodelog.args.type === 1n) {
+
+          const tokenContract = new ethers.Contract(
+            hiIQCOntract,
+            erc20Abi,
+            rpcProvider,
+          )
+
+          if (decodelog.eventName === 'Deposit') {
             const { provider, value } = decodelog.args
             if (value !== undefined) {
               const existingHolder = await this.checkExistingHolders(provider)
-              if (existingHolder) {
-                existingHolder.tokens = new Decimal(existingHolder.tokens)
-                  .plus(value.toString())
-                  .toString()
-                await this.hiIQHoldersAddressRepo.save(existingHolder)
-              } else {
+              const timestamp = parseInt(log.timeStamp, 16)
+              const logTime = new Date(timestamp * 1000).toISOString()
+
+              const balance = await tokenContract.balanceOf(provider, {
+                blockTag: log.blockNumber,
+              })
+
+              const [decimals] = await Promise.all([
+                tokenContract.decimals(),
+                tokenContract.symbol(),
+              ])
+
+              const formattedBalance = ethers.utils.formatUnits(
+                balance,
+                decimals,
+              )
+
+              if (existingHolder && formattedBalance !== '0.0') {
+                await this.hiIQHoldersAddressRepo
+                  .createQueryBuilder()
+                  .update(HiIQHolderAddress)
+                  .set({ tokens: formattedBalance, updated: logTime })
+                  .where('address = :address', {
+                    address: existingHolder.address,
+                  })
+                  .execute()
+              }
+              if (!existingHolder && formattedBalance !== '0.0') {
                 try {
                   const newHolder = this.hiIQHoldersAddressRepo.create({
                     address: provider,
-                    tokens: `${ethers.utils.formatEther(value)}`,
+                    tokens: `${formattedBalance}`,
+                    updated: logTime,
                   })
                   await this.hiIQHoldersAddressRepo.save(newHolder)
                 } catch (e: any) {
@@ -222,7 +254,7 @@ class HiIQHolderService {
     const endTimestamp = startTimestamp + oneDayInSeconds
     const key = this.etherScanApiKey()
     const rootUrl = `https://api${
-      this.provider().includes('mainnet') ? '' : '-goerli'
+      this.providerUrl().includes('mainnet') ? '' : '-goerli'
     }`
     const buildUrl = (fallbackTimestamp: number, timestamp?: number) =>
       `${rootUrl}.etherscan.io/api?module=block&action=getblocknobytime&timestamp=${
@@ -259,10 +291,7 @@ class HiIQHolderService {
   ): Promise<HiIQHolderAddress[]> {
     const repo = await this.hiIQHoldersAddressRepo
       .createQueryBuilder()
-      .orderBy(
-        args.order && args.order === 'updated' ? 'updated' : 'tokens',
-        args.direction,
-      )
+      .orderBy('tokens', args.direction)
       .skip(args.offset)
       .take(args.limit)
       .getMany()


### PR DESCRIPTION
# SearchhiIQHoldersByAddress API

_Created api to search hiiq users using address_

## How should this be tested?

1. Run pnpm dev in terminal
2. Open localhost:7500/graphql
3. Run the following in the playground:
 query {
  searchHiIQHoldersByAddress(address: "0x1234567890") {
   created
    address
    tokens
  }
}
Replace 0x1234567890 with hiIQ user address

## Linked issues

closes https://github.com/EveripediaNetwork/issues/issues/3427
