### PR TITLE
Resolve DateTime.serialize() Returns Null for Non-nullable Field

### DIFF
--- a/src/App/marketCap/marketCap.service.ts
+++ b/src/App/marketCap/marketCap.service.ts
@@ -184,12 +184,18 @@ class MarketCapService {
         this.CACHED_WIKI = result as RankPageWiki
       }
 
-      await this.cacheManager.set(id, result, 3600 * 1000)
+      await this.cacheManager.set(id, result, 60 * 60 * 1000) // Set cache for 1 hour
 
       return result as unknown as RankPageWiki
     }
-
-    return cachedWiki
+    const processedCachedWiki = {
+      ...cachedWiki,
+      wiki: {
+        ...cachedWiki.wiki,
+        created: new Date(cachedWiki.wiki.created),
+      },
+    }
+    return processedCachedWiki as RankPageWiki
   }
 
   async getWikiData(


### PR DESCRIPTION
# Resolve DateTime.serialize() Returns Null for Non-nullable Field

This PR resolves the issue with serializing date cached response which returns null when when serialized.

## Linked issues

closes https://github.com/EveripediaNetwork/issues/issues/3969
