### PR TITLE
Fix: empty cache

### DIFF
--- a/src/App/Blog/blog.resolver.ts
+++ b/src/App/Blog/blog.resolver.ts
@@ -1,7 +1,6 @@
 import { Resolver, Query, Args, Int, Mutation } from '@nestjs/graphql'
 import BlogService from './blog.service'
 import { Blog } from './blog.dto'
-import HiddenBlog from './hideBlog.entity'
 
 @Resolver(() => Blog)
 class BlogResolver {

--- a/src/App/Blog/blog.service.ts
+++ b/src/App/Blog/blog.service.ts
@@ -153,7 +153,10 @@ class BlogService {
       }),
     ).then((blogArrays) => blogArrays.flat())
 
-    await this.cacheManager.set(this.BLOG_CACHE_KEY, blogs, 7200 * 1000)
+    if (blogs.length > 0) {
+      await this.cacheManager.set(this.BLOG_CACHE_KEY, blogs, 7200 * 1000)
+    }
+
     return blogs
   }
 
@@ -165,7 +168,7 @@ class BlogService {
 
     let blogs = await this.cacheManager.get<Blog[]>(this.BLOG_CACHE_KEY)
     if (!blogs) {
-      blogs = await Promise.all(
+      const successfulBlog = await Promise.all(
         accounts.map(async (account) => {
           try {
             if (!account) return []
@@ -181,8 +184,14 @@ class BlogService {
           }
         }),
       ).then((blogArrays) => blogArrays.flat())
-      await this.cacheManager.set(this.BLOG_CACHE_KEY, blogs, 7200 * 1000)
+
+      if (successfulBlog.length > 0) {
+        await this.cacheManager.set(this.BLOG_CACHE_KEY, blogs, 7200 * 1000)
+      }
+
+      blogs = successfulBlog
     }
+
     return this.filterHiddenBlogs(blogs || [])
   }
 

--- a/src/App/Blog/blog.service.ts
+++ b/src/App/Blog/blog.service.ts
@@ -201,7 +201,10 @@ class BlogService {
       return null
     }
 
-    const blogs = await this.cacheManager.get<Blog[]>(this.BLOG_CACHE_KEY)
+    let blogs = await this.cacheManager.get<Blog[]>(this.BLOG_CACHE_KEY)
+    if (!blogs) {
+      blogs = await this.refreshBlogCache()
+    }
 
     const blog =
       blogs?.find((e: Blog) => e.digest === digest) ??


### PR DESCRIPTION
# Fix blog cache issue to prevent caching empty arrays

This PR ensures that only successful blog queries with actual data are cached. Previously, failed or empty queries were being cached, leading to persistent display issues until the cache was manually cleared (e.g., by triggering a new build/deploy).


## Linked issues

closes https://github.com/EveripediaNetwork/issues/issues/4080

