### PR TITLE
Refactor ActivityRepository and tests

### DIFF
--- a/src/App/Activities/activity.repository.spec.ts
+++ b/src/App/Activities/activity.repository.spec.ts
@@ -17,7 +17,6 @@ describe('ActivityRepository', () => {
   let repository: ActivityRepository
   let moduleRef: TestingModule
 
-  // Helper function to create query builder mock
   const createQueryBuilderMock = () => {
     const mock = {
       select: jest.fn().mockReturnThis(),
@@ -38,7 +37,6 @@ describe('ActivityRepository', () => {
     return mock
   }
 
-  // Helper function to create test data
   const createTestActivity = () => {
     const activity = new Activity()
     activity.id = 'test-id'

--- a/src/App/Activities/activity.resolver.ts
+++ b/src/App/Activities/activity.resolver.ts
@@ -59,15 +59,8 @@ class ActivityResolver {
   }
 
   @Query(() => [Activity])
-  async activitiesByUser(
-    @Args() args: ActivityArgsByUser,
-    @Context() context: any,
-    @SelectedFields({ nested: true, path: 'content' }) fields: string[],
-  ) {
-    const { req } = context
-    const { query } = req.body
-
-    return this.activityRepository.getActivitiesByUser(args, query, fields)
+  async activitiesByUser(@Args() args: ActivityArgsByUser) {
+    return this.activityRepository.getActivitiesByUser(args.userId)
   }
 
   @Query(() => Activity)


### PR DESCRIPTION
# Refactor ActivityRepository and tests

- Updated ActivityRepository to improve query building and error handling.
- Introduced helper methods for building base queries and applying conditions.
- Enhanced test cases for user activity counting and fetching activities by user.
- Simplified the activitiesByUser resolver to directly call the repository method.
- Added logging for error handling in activity processing.

## How should this be tested?

1. Pull the branch and start the application
2. Navigate to the localhost:7500/graphql
3. Test the activties query
4. Run pnpm test activity.repository.spec.ts

## Notes or observations

_jot down something here_

## Linked issues

closes https://github.com/EveripediaNetwork/issues/issues/
