### PR TITLE
Replace CMC with CoinGecko in API integration

### DIFF
--- a/src/App/tokenStats/models/tokenData.model.ts
+++ b/src/App/tokenStats/models/tokenData.model.ts
@@ -47,7 +47,7 @@ export class TokenStatArgs {
   @Validate(ValidStringParams)
   tokenName!: string
 
-  @Field(() => String, { nullable: true, name: 'cmcTokenName' })
+  @Field(() => String, { nullable: true, name: 'cgAltTokenName' })
   @Validate(ValidStringParams)
-  cmcTokenName?: string
+  cgAltTokenName?: string
 }

--- a/src/App/tokenStats/tokenStats.resolver.ts
+++ b/src/App/tokenStats/tokenStats.resolver.ts
@@ -10,7 +10,7 @@ class TokenStatsResolver {
   async getTokenStats(@Args() args: TokenStatArgs): Promise<TokenData> {
     const result = await this.tokenStatsService.getStats(
       args.tokenName.toLowerCase(),
-      args.cmcTokenName?.toLowerCase(),
+      args.cgAltTokenName?.toLowerCase(),
     )
     return result
   }

--- a/src/App/tokenStats/tokenStats.service.ts
+++ b/src/App/tokenStats/tokenStats.service.ts
@@ -11,16 +11,15 @@ class TokenStatsService {
     @Inject(CACHE_MANAGER) private cacheManager: Cache,
   ) {}
 
-  async getStats(name: string, cmcName?: string): Promise<TokenData> {
+  async getStats(name: string, cgAltName?: string): Promise<TokenData> {
     const cached: TokenData | null | undefined = await this.cacheManager.get(
       name.toLowerCase(),
     )
     if (cached) {
       return cached
     }
-    const result = await this.statsGetterService.getStats(name, cmcName)
-    const { id } = result.id
-    await this.cacheManager.set(id, result)
+    const result = await this.statsGetterService.getStats(name, cgAltName)
+    await this.cacheManager.set(name.toLowerCase(), result)
     return result
   }
 }


### PR DESCRIPTION
# Replace CoinMarketCap with CoinGecko for token statistics

This PR replaces CoinMarketCap (CMC) with CoinGecko (CG) as the primary data source for token statistics. The implementation now fully relies on CoinGecko for all token data, removing the dependency on CoinMarketCap.

## How should this be tested?

1. Make sure you have a valid CoinGecko API key set in your environment variables:
   ```
   COINGECKO_API_KEY=your_api_key_here
   ```

2. Start the application and test with GraphQL Playground:
   ```
   pnpm run start:dev
   ```

3. Open GraphQL Playground (typically at http://localhost:3000/graphql) and run test queries:
   ```graphql
   query {
     tokenStats(tokenName: "bitcoin") {
       name
       symbol
       token_price_in_usd
       market_cap
       volume
       price_percentage_change
     }
   }
   ```

4. Test with an alternate token name:
   ```graphql
   query {
     tokenStats(tokenName: "shiba", cgAltTokenName: "shiba-inu") {
       name
       symbol
       token_price_in_usd
       market_cap
     }
   }
   ```

## Linked issues
closes https://github.com/EveripediaNetwork/issues/issues/4118