### PR TITLE
refactor(ai): adds reolver to make the ai search use graphql

### DIFF
--- a/src/App/Search/search.module.ts
+++ b/src/App/Search/search.module.ts
@@ -3,11 +3,12 @@ import { HttpModule } from '@nestjs/axios'
 import { ConfigModule } from '@nestjs/config'
 import SearchController from './search.controller'
 import SearchService from './search.service'
+import SearchResolver from './search.resolver'
 
 @Module({
   imports: [HttpModule, ConfigModule],
   controllers: [SearchController],
-  providers: [SearchService],
+  providers: [SearchService, SearchResolver],
   exports: [SearchService],
 })
 export default class SearchModule {}

--- a/src/App/Search/search.resolver.ts
+++ b/src/App/Search/search.resolver.ts
@@ -1,4 +1,5 @@
 import { Args, Query, Resolver, Field, ObjectType } from '@nestjs/graphql'
+import { BadRequestException } from '@nestjs/common'
 import SearchService from './search.service'
 
 @ObjectType()
@@ -25,6 +26,9 @@ class SearchResolver {
 
   @Query(() => SearchResult)
   async search(@Args('query') query: string): Promise<SearchResult> {
+    if (!query?.trim()) {
+      throw new BadRequestException('Search query cannot be empty.')
+    }
     return this.searchService.search(query)
   }
 }

--- a/src/App/Search/search.resolver.ts
+++ b/src/App/Search/search.resolver.ts
@@ -1,0 +1,32 @@
+import { Args, Query, Resolver, Field, ObjectType } from '@nestjs/graphql'
+import SearchService from './search.service'
+
+@ObjectType()
+class WikiSuggestion {
+  @Field(() => String)
+  id!: string
+
+  @Field(() => String)
+  title!: string
+}
+
+@ObjectType()
+class SearchResult {
+  @Field(() => [WikiSuggestion], { nullable: true })
+  suggestions?: WikiSuggestion[]
+
+  @Field(() => String, { nullable: true })
+  answer?: string
+}
+
+@Resolver(() => SearchResult)
+class SearchResolver {
+  constructor(private readonly searchService: SearchService) {}
+
+  @Query(() => SearchResult)
+  async search(@Args('query') query: string): Promise<SearchResult> {
+    return this.searchService.search(query)
+  }
+}
+
+export default SearchResolver


### PR DESCRIPTION
# refactor(ai): add resolver to make the ai search use graphql

Refactors the search functionality from the REST controller to the GraphQL resolver pattern. The search service now returns structured data through GraphQL queries with proper type definitions for wiki suggestions and AI-generated answers.

## How should this be tested?
1. Start the GraphQL playground/IDE
2. Execute a search query: `query { search(query: "your search term") { suggestions { id title } answer } }`
3. Verify suggestions return wiki IDs and titles
4. Verify answer field contains an AI-generated response
5. Test with empty/invalid queries to ensure proper handling

## Notes or observations
- Kept the resolver implementation minimal to match the existing service structure
- WikiSuggestion type matches the service's `Pick<Wiki, 'id' | 'title'>[]` response
- SearchResult directly mirrors the service's `{ suggestions, answer }` return format
- No breaking changes to existing search service logic


<img width="1436" alt="Screenshot 2025-06-30 at 10 23 47 PM" src="https://github.com/user-attachments/assets/cbf4c173-2d1d-4bc4-a9d1-e3734e12f982" />

