### PR TITLE
SearchService: inject IQ Learn (English) into answers plus Markdown cleanup and link parsing.

### DIFF
--- a/src/App/Search/search.resolver.ts
+++ b/src/App/Search/search.resolver.ts
@@ -1,8 +1,9 @@
 // biome-ignore lint: Biome does not fully support TypeScript decorators in NestJS.
-import { Args, Query, Resolver } from '@nestjs/graphql'
-import { BadRequestException } from '@nestjs/common'
+import { Args, Query, Resolver, Mutation } from '@nestjs/graphql'
+import { BadRequestException, UseGuards } from '@nestjs/common'
 import SearchService from './search.service'
 import { SearchResult } from './search.types'
+import AuthGuard from '../utils/admin.guard'
 
 @Resolver(() => SearchResult)
 class SearchResolver {
@@ -13,11 +14,23 @@ class SearchResolver {
     @Args('query') query: string,
     @Args('withAnswer', { type: () => Boolean, defaultValue: true })
     withAnswer: boolean,
-  ): Promise<SearchResult> {
+  ) {
     if (!query?.trim()) {
       throw new BadRequestException('Search query cannot be empty.')
     }
     return this.searchService.search(query, withAnswer)
+  }
+
+  @Mutation(() => Boolean)
+  @UseGuards(AuthGuard)
+  async clearLearnDocsCache() {
+    return this.searchService.clearLearnDocsCache()
+  }
+
+  @Mutation(() => Boolean)
+  @UseGuards(AuthGuard)
+  async refreshLearnDocsCache() {
+    return this.searchService.refreshLearnDocsCache()
   }
 }
 

--- a/src/App/Search/search.resolver.ts
+++ b/src/App/Search/search.resolver.ts
@@ -14,7 +14,7 @@ class SearchResolver {
     @Args('query') query: string,
     @Args('withAnswer', { type: () => Boolean, defaultValue: true })
     withAnswer: boolean,
-  ) {
+  ): Promise<SearchResult> {
     if (!query?.trim()) {
       throw new BadRequestException('Search query cannot be empty.')
     }
@@ -23,13 +23,13 @@ class SearchResolver {
 
   @Mutation(() => Boolean)
   @UseGuards(AuthGuard)
-  async clearLearnDocsCache() {
+  async clearLearnDocsCache(): Promise<boolean> {
     return this.searchService.clearLearnDocsCache()
   }
 
   @Mutation(() => Boolean)
   @UseGuards(AuthGuard)
-  async refreshLearnDocsCache() {
+  async refreshLearnDocsCache(): Promise<boolean> {
     return this.searchService.refreshLearnDocsCache()
   }
 }

--- a/src/App/Search/search.service.ts
+++ b/src/App/Search/search.service.ts
@@ -91,9 +91,6 @@ class SearchService {
 
   private readonly isProduction: boolean
 
-  private learnDocs: Awaited<ReturnType<typeof crawlIQLearnEnglish>> | null =
-    null
-
   private static readonly ALLOWED_METADATA = new Set([
     'website',
     'twitter_profile',

--- a/src/App/Search/search.types.ts
+++ b/src/App/Search/search.types.ts
@@ -37,6 +37,15 @@ export class WikiContent {
 }
 
 @ObjectType()
+export class LearnDocs {
+  @Field(() => String)
+  title!: string
+
+  @Field(() => String)
+  content!: string
+}
+
+@ObjectType()
 export class SearchResult {
   @Field(() => [WikiSuggestion], { nullable: true })
   suggestions?: WikiSuggestion[]
@@ -46,4 +55,7 @@ export class SearchResult {
 
   @Field(() => String, { nullable: true })
   answer?: string
+
+  @Field(() => [LearnDocs], { nullable: true })
+  learnDocs?: LearnDocs[]
 }

--- a/src/App/utils/crawl-iq-learn.ts
+++ b/src/App/utils/crawl-iq-learn.ts
@@ -83,15 +83,21 @@ export async function crawlIQLearnEnglish() {
           ).replace(/\.md$/i, '')
           let title = h1 || fallback
 
-          if (title.toLowerCase() === 'contracts') {
-            title = 'View IQ token contract addresses on different chains'
+          const renames: Record<string, string> = {
+            contracts: 'View IQ token contract addresses on different chains',
+          }
+
+          const newTitle = renames[title.toLowerCase()]
+          if (newTitle) {
+            title = newTitle
           }
 
           return { title, content } as LearnDocs
-        } catch (error: any) {
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error)
           console.error(
             `Failed to fetch or process learn doc at ${url}:`,
-            error.message || error,
+            message,
           )
           return null
         }
@@ -99,11 +105,9 @@ export async function crawlIQLearnEnglish() {
     )
 
     return results.filter((x): x is LearnDocs => x !== null)
-  } catch (error: any) {
-    console.error(
-      'Failed to fetch English links index:',
-      error.message || error,
-    )
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    console.error('Failed to fetch English links index:', message)
     return []
   }
 }

--- a/src/App/utils/crawl-iq-learn.ts
+++ b/src/App/utils/crawl-iq-learn.ts
@@ -1,8 +1,8 @@
+import { LearnDocs } from '../Search/search.types'
+
 const INDEX_URL = 'https://learn.iq.wiki/iq/llms.txt'
 const ORIGIN = 'https://learn.iq.wiki'
 const UA = 'Mozilla/5.0 (NodeBot)'
-
-export type LearnDoc = { title: string; content: string }
 
 function cleanMarkdown(content: string) {
   return (
@@ -87,7 +87,7 @@ export async function crawlIQLearnEnglish() {
             title = 'View IQ token contract addresses on different chains'
           }
 
-          return { title, content } as LearnDoc
+          return { title, content } as LearnDocs
         } catch (error: any) {
           console.error(
             `Failed to fetch or process learn doc at ${url}:`,
@@ -98,7 +98,7 @@ export async function crawlIQLearnEnglish() {
       }),
     )
 
-    return results.filter((x): x is LearnDoc => x !== null)
+    return results.filter((x): x is LearnDocs => x !== null)
   } catch (error: any) {
     console.error(
       'Failed to fetch English links index:',

--- a/src/App/utils/crawl-iq-learn.ts
+++ b/src/App/utils/crawl-iq-learn.ts
@@ -1,0 +1,87 @@
+const INDEX_URL = 'https://learn.iq.wiki/iq/llms.txt'
+const ORIGIN = 'https://learn.iq.wiki'
+const UA = 'Mozilla/5.0 (NodeBot)'
+
+export type LearnDoc = { title: string; content: string }
+
+function cleanMarkdown(content: string) {
+  return (
+    content
+      // remove images
+      .replace(/!\[.*?\]\(.*?\)/g, '')
+      // remove gitbook-style embeds
+      .replace(/{%\s*embed\s+url="[^"]*"\s*%}/g, '')
+      // remove <figcaption>/<figcapture>
+      .replace(/<\/?figcaption[^>]*>/gi, '')
+      .replace(/<\/?figcapture[^>]*>/gi, '')
+      .trim()
+  )
+}
+
+async function fetchEnglishBlock() {
+  const res = await fetch(INDEX_URL, { headers: { 'User-Agent': UA } })
+  if (!res.ok) throw new Error(`Failed to fetch index: ${res.status}`)
+  const text = await res.text()
+
+  const lines = text.split(/\r?\n/)
+  const start = lines.findIndex((l) => /^##\s*English\s*$/i.test(l.trim()))
+  if (start === -1) return ''
+  let end = lines.length
+  for (let i = start + 1; i < lines.length; i += 1) {
+    if (/^##\s+/.test(lines[i].trim())) {
+      end = i
+      break
+    }
+  }
+  return lines.slice(start, end).join('\n')
+}
+
+async function fetchEnglishLinks() {
+  const block = await fetchEnglishBlock()
+
+  const matches = [...block.matchAll(/\((\/iq\/[^\s)]+)\)/g)]
+  const paths = matches.map((m) => {
+    let p = m[1].trim()
+    if (!p.endsWith('.md')) p = `${p}.md`
+    return p
+  })
+
+  const abs = Array.from(new Set(paths)).map((p) =>
+    new URL(p, ORIGIN).toString(),
+  )
+
+  return abs
+}
+
+export async function crawlIQLearnEnglish() {
+  const urls = await fetchEnglishLinks()
+
+  const results = await Promise.all(
+    urls.map(async (url) => {
+      try {
+        const res = await fetch(url, { headers: { 'User-Agent': UA } })
+        if (!res.ok) {
+          return null
+        }
+        let content = await res.text()
+        content = cleanMarkdown(content)
+
+        const h1 = content.match(/^#\s+(.*)$/m)?.[1]?.trim()
+        const fallback = decodeURIComponent(
+          new URL(url).pathname.split('/').filter(Boolean).pop() || 'Untitled',
+        ).replace(/\.md$/i, '')
+        let title = h1 || fallback
+
+        if (title.toLowerCase() === 'contracts') {
+          title = 'View IQ token contract addresses on different chains'
+        }
+
+        return { title, content } as LearnDoc
+      } catch (e: any) {
+        return null
+      }
+    }),
+  )
+
+  return results.filter((x): x is LearnDoc => x !== null)
+}

--- a/src/App/utils/crawl-iq-learn.ts
+++ b/src/App/utils/crawl-iq-learn.ts
@@ -58,7 +58,7 @@ async function fetchEnglishBlock(logger: Logger) {
 
   const block = lines.slice(start, end).join('\n').trim()
   if (!block) {
-    logger?.warn?.(
+    logger.warn(
       'English block parsed as empty; upstream format may have changed',
     )
   }


### PR DESCRIPTION



# PR Description

## Summary

This PR integrates **IQ Learn (English)** content into the answer flow. We fetch English pages from `llms.txt`, clean the Markdown (remove images/embeds/figcaptions), normalize titles (including a custom rename for **Contracts**), and inject the full Learn content into the LLM prompt as additional context. **No caching** is applied by design in this change.

## What changed

* **New utility:** `utils/crawl-iq-learn.ts`

  * Reads `https://learn.iq.wiki/iq/llms.txt`, isolates the **English** section.
  * Extracts `(/iq/...)` links with `matchAll`, ensures `.md`, converts to absolute URLs.
  * Fetches all pages in parallel (`Promise.all`) with a UA header.
  * Cleans Markdown:

    * strips `![](...)` images,
    * removes `{% embed url="..." %}` blocks,
    * removes `<figcaption>` / `<figcapture>` tags.
  * Title = first H1 or filename; special-case: **Contracts** → **View IQ token contract addresses on different chains**.
  * Returns `Array<{ title, content }>`.

* **SearchService integration**

  * `import { crawlIQLearnEnglish } from '../utils/crawl-iq-learn'`.
  * `getLearnDocs()` now **fetches Learn docs on demand** (no cache), builds a readable prompt block:

    * Header: explains these are learning materials about the IQ token / BrainDAO ecosystem.
    * Body: enumerates `[L#] Title` followed by **full** content (no truncation).
  * `answerQuestion()` injects the Learn block as an additional assistant message after the “AVAILABLE WIKIS” section.
  * `searchWithoutCache()` includes the Learn block in the returned payload (`learnDocs` string), alongside `suggestions`, `wikiContents`, and `answer`.

## Rationale

* IQ Learn contains authoritative how-to/reference material that complements internal wikis. Injecting it directly into the prompt improves answer coverage for IQ-specific tasks without changing the ranking flow.

## API / Behavior Notes

* Response now includes:

  * `learnDocs: string` — the formatted Learn context string included in the LLM prompt.
* No changes to the `wikis` JSON schema or the ranking pipeline.
* Learn content is fetched **every request** (no cache), which is intentional in this PR.

## Performance / Risk

* **Network & tokens:** Full Learn content is injected, which increases prompt size and outbound requests per call.
* **Follow-ups (optional):**

  * Add a simple TTL cache (e.g., 24h) or gating to reduce cost.
  * Consider updating the system prompt in `answerQuestion()` to explicitly mention IQ Learn as an allowed source (currently it says “ONLY the provided wiki content” while we also inject Learn context).

## Testing

* **Utility**

  * Verify English section extraction from `llms.txt`.
  * Ensure links are absolute and end with `.md`.
  * Confirm cleaning removes images/embeds/figcaption elements.
  * Check title fallback + “Contracts” rename.
* **Service**

  * Call `search(..., withAnswer: true)` and validate that:

    * The Learn block appears between “AVAILABLE WIKIS” and the user message in the prompt.
    * The returned payload includes `learnDocs` (string) plus `suggestions`, `wikiContents`, `answer`.
* **Edge cases**

  * Empty or failing Learn fetch returns an empty Learn block gracefully.
  * Non-English sections are ignored.


## Screenshots

<img width="1438" height="685" alt="Screenshot 2025-08-26 at 5 10 52 AM" src="https://github.com/user-attachments/assets/8c1f7264-723c-41c7-8072-13b4911e084f" />
